### PR TITLE
🧪 [testing improvement] Add error path test for getFirstImageFromFolder

### DIFF
--- a/src/utils/awsS3UtilityFunctions.test.ts
+++ b/src/utils/awsS3UtilityFunctions.test.ts
@@ -1,0 +1,57 @@
+import { expect, test, describe, mock, spyOn, beforeEach } from "bun:test";
+
+const mockSend = mock();
+
+mock.module("@aws-sdk/client-s3", () => {
+  return {
+    S3Client: class {
+      send = mockSend;
+    },
+    ListObjectsV2Command: class {
+      constructor(public params: any) {}
+    },
+  };
+});
+
+// Re-import to ensure it uses the mock
+import { getFirstImageFromFolder } from "./awsS3UtilityFunctions";
+
+describe("getFirstImageFromFolder", () => {
+  beforeEach(() => {
+    mockSend.mockClear();
+    mockSend.mockImplementation(async () => {
+       return { Contents: [] };
+    });
+  });
+
+  test("should return the first non-zero size object", async () => {
+    mockSend.mockImplementation(async () => {
+      return {
+        Contents: [
+          { Key: "folder/", Size: 0 },
+          { Key: "folder/image.jpg", Size: 1024 },
+        ]
+      };
+    });
+
+    const result = await getFirstImageFromFolder("folder/");
+    expect(result?.Key).toBe("folder/image.jpg");
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("should throw and log error when S3 client fails", async () => {
+    const error = new Error("S3 error");
+    mockSend.mockImplementation(async () => {
+      throw error;
+    });
+
+    const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(getFirstImageFromFolder("folder/")).rejects.toThrow("S3 error");
+      expect(consoleSpy).toHaveBeenCalledWith("Error fetching objects:", error);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/src/utils/awsS3UtilityFunctions.ts
+++ b/src/utils/awsS3UtilityFunctions.ts
@@ -6,13 +6,20 @@ import {
 
 const BUCKET_NAME = "giorgio-paoloni-gallery-storage";
 
-const client = new S3Client({
-  region: process.env.AWS_REGION,
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-  },
-});
+let client: S3Client;
+
+export const getClient = () => {
+  if (!client) {
+    client = new S3Client({
+      region: process.env.AWS_REGION,
+      credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      },
+    });
+  }
+  return client;
+};
 
 // Funzione per ottenere tutti gli oggetti in una cartella specifica
 export const getFoldersInFolder = async (prefix: string) => {
@@ -24,7 +31,7 @@ export const getFoldersInFolder = async (prefix: string) => {
   const command = new ListObjectsV2Command(params);
 
   try {
-    const response = await client.send(command);
+    const response = await getClient().send(command);
     return response.Contents?.filter(
       (content) =>
         content.Key?.split("/").length === prefix.split("/").length + 1 &&
@@ -45,7 +52,7 @@ export const getFirstImageFromFolder = async (prefix: string) => {
   const command = new ListObjectsV2Command(params);
 
   try {
-    const response = await client.send(command);
+    const response = await getClient().send(command);
     return response.Contents?.find((content) => content.Size !== 0);
   } catch (error) {
     console.error("Error fetching objects:", error);
@@ -61,7 +68,7 @@ export const getImagesFromFolder = async (prefix: string) => {
 
   const command = new ListObjectsV2Command(params);
   try {
-    const response = await client.send(command);
+    const response = await getClient().send(command);
     return response.Contents?.filter(
       (content) =>
         content.Key?.split("/").length === prefix.split("/").length + 1 &&


### PR DESCRIPTION
This PR addresses the missing error path test in `getFirstImageFromFolder` within `src/utils/awsS3UtilityFunctions.ts`.

### 🎯 What
The testing gap addressed was the lack of verification for the error handling logic in the S3 utility function. If the S3 client failed, we weren't programmatically ensuring that the error was both logged and re-thrown.

### 📊 Coverage
- **Happy Path**: Verified that the function correctly identifies and returns the first non-zero size object from the S3 response.
- **Error Path**: Verified that when the S3 client throws an error, the function logs the error message to the console and re-throws the error as expected.

### ✨ Result
The addition of these tests increases the reliability of the S3 utility functions and ensures that future changes to error handling will be caught by the test suite. The refactoring to use a `getClient` helper also makes the entire module more robust and easier to test.

---
*PR created automatically by Jules for task [16957717204194086968](https://jules.google.com/task/16957717204194086968) started by @Giorey01*