### PR TITLE
🧪 [add error path test for getFoldersInFolder]

### DIFF
--- a/src/utils/awsS3UtilityFunctions.test.ts
+++ b/src/utils/awsS3UtilityFunctions.test.ts
@@ -14,7 +14,7 @@ mock.module("@aws-sdk/client-s3", () => {
 });
 
 // Re-import to ensure it uses the mock
-import { getFirstImageFromFolder } from "./awsS3UtilityFunctions";
+import { getFirstImageFromFolder, getFoldersInFolder } from "./awsS3UtilityFunctions";
 
 describe("getFirstImageFromFolder", () => {
   beforeEach(() => {
@@ -49,6 +49,31 @@ describe("getFirstImageFromFolder", () => {
 
     try {
       await expect(getFirstImageFromFolder("folder/")).rejects.toThrow("S3 error");
+      expect(consoleSpy).toHaveBeenCalledWith("Error fetching objects:", error);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});
+
+describe("getFoldersInFolder", () => {
+  beforeEach(() => {
+    mockSend.mockClear();
+    mockSend.mockImplementation(async () => {
+       return { Contents: [] };
+    });
+  });
+
+  test("should throw and log error when S3 client fails", async () => {
+    const error = new Error("S3 error in getFoldersInFolder");
+    mockSend.mockImplementation(async () => {
+      throw error;
+    });
+
+    const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(getFoldersInFolder("folder/")).rejects.toThrow("S3 error in getFoldersInFolder");
       expect(consoleSpy).toHaveBeenCalledWith("Error fetching objects:", error);
     } finally {
       consoleSpy.mockRestore();


### PR DESCRIPTION
🎯 **What:** The testing gap in `getFoldersInFolder` where S3 client failures were not explicitly tested for their error handling path has been addressed.
📊 **Coverage:** The scenario where the mocked S3 client throws an error when attempting to fetch the folders is now tested. The test verifies that the error is correctly caught, logged using `console.error`, and re-thrown.
✨ **Result:** Increased test coverage by adding the error path, ensuring that if `getFoldersInFolder` fails to fetch from S3, the error propagates and is logged as expected.

---
*PR created automatically by Jules for task [17639266557950678026](https://jules.google.com/task/17639266557950678026) started by @Giorey01*