### PR TITLE
🧪 testing improvement for getImagesFromFolder

### DIFF
--- a/src/utils/awsS3UtilityFunctions.test.ts
+++ b/src/utils/awsS3UtilityFunctions.test.ts
@@ -14,7 +14,58 @@ mock.module("@aws-sdk/client-s3", () => {
 });
 
 // Re-import to ensure it uses the mock
-import { getFirstImageFromFolder } from "./awsS3UtilityFunctions";
+import { getFirstImageFromFolder, getImagesFromFolder } from "./awsS3UtilityFunctions";
+
+describe("getImagesFromFolder", () => {
+  beforeEach(() => {
+    mockSend.mockClear();
+    mockSend.mockImplementation(async () => {
+       return { Contents: [] };
+    });
+  });
+
+  test("should filter and return only direct child objects with non-zero size", async () => {
+    mockSend.mockImplementation(async () => {
+      return {
+        Contents: [
+          { Key: "folder/", Size: 0 },
+          { Key: "folder/subfolder", Size: 0 },
+          { Key: "folder/image1.jpg", Size: 1024 },
+          { Key: "folder/image2.png", Size: 2048 },
+          { Key: "folder/subfolder/image3.jpg", Size: 4096 },
+        ]
+      };
+    });
+
+    // For prefix "folder", length is 1
+    // prefix "folder".split("/") -> ["folder"] (length 1)
+    // content "folder/image1.jpg".split("/") -> ["folder", "image1.jpg"] (length 2)
+    // 2 === 1 + 1 (true)
+    const result = await getImagesFromFolder("folder");
+
+    expect(result).toBeDefined();
+    expect(result?.length).toBe(2);
+    expect(result?.[0].Key).toBe("folder/image1.jpg");
+    expect(result?.[1].Key).toBe("folder/image2.png");
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("should throw and log error when S3 client fails", async () => {
+    const error = new Error("S3 error");
+    mockSend.mockImplementation(async () => {
+      throw error;
+    });
+
+    const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(getImagesFromFolder("folder/")).rejects.toThrow("S3 error");
+      expect(consoleSpy).toHaveBeenCalledWith("Error fetching objects:", error);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});
 
 describe("getFirstImageFromFolder", () => {
   beforeEach(() => {


### PR DESCRIPTION
🎯 **What:** The testing gap for `getImagesFromFolder` in `src/utils/awsS3UtilityFunctions.ts` has been addressed. It was previously lacking any unit test coverage.
📊 **Coverage:** Scenarios covered include:
- The happy path, where the S3 client returns a mixed list of objects (the directory itself, direct child images, and sub-directory files) and the function must correctly filter and return only the direct child objects with non-zero size. It also adds a helpful comment explaining how the length-based path matching strategy works.
- The error condition, where an S3 client throws an exception and the utility correctly catches it, calls `console.error`, and re-throws the error.
✨ **Result:** Increased test coverage and confidence in the AWS S3 Utility function reliability, ensuring any refactor down the line will be caught if the filtering behavior changes.

---
*PR created automatically by Jules for task [8961190983898596909](https://jules.google.com/task/8961190983898596909) started by @Giorey01*