### PR TITLE
Fix build failure due to missing closing braces in awsS3UtilityFunctions.ts

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test-setup.ts"]

--- a/src/utils/awsS3UtilityFunctions.ts
+++ b/src/utils/awsS3UtilityFunctions.ts
@@ -43,7 +43,7 @@ export const getFoldersInFolder = unstable_cache(
     console.error("Error fetching objects:", error);
     throw error;
   }
-);
+});
 
 export const getFirstImageFromFolder = unstable_cache(
   async (prefix: string) => {
@@ -61,7 +61,7 @@ export const getFirstImageFromFolder = unstable_cache(
     console.error("Error fetching objects:", error);
     throw error;
   }
-);
+});
 
 export const getImagesFromFolder = unstable_cache(
   async (prefix: string) => {
@@ -82,4 +82,4 @@ export const getImagesFromFolder = unstable_cache(
     console.error("Error fetching objects:", error);
     throw error;
   }
-);
+});

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,0 +1,7 @@
+import { mock } from "bun:test";
+
+mock.module("next/cache", () => {
+  return {
+    unstable_cache: (cb: any) => cb,
+  };
+});


### PR DESCRIPTION
This commit resolves a build failure caused by missing closing braces in the arrow functions passed to `unstable_cache` in `src/utils/awsS3UtilityFunctions.ts`. I have added the missing braces for `getFoldersInFolder`, `getFirstImageFromFolder`, and `getImagesFromFolder`. I also added a `bunfig.toml` and a test setup script to support testing Next.js cache functionality using Bun.

---
*PR created automatically by Jules for task [5316242135388799496](https://jules.google.com/task/5316242135388799496) started by @Giorey01*