### PR TITLE
Redesign Home Page Theme and Layout

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -1,0 +1,12 @@
+
+> giorgio-paoloni-portfolio@0.1.0 dev
+> next dev
+
+  ▲ Next.js 14.2.3
+  - Local:        http://localhost:3000
+
+ ✓ Starting...
+ ✓ Ready in 2.5s
+ ○ Compiling / ...
+ ✓ Compiled / in 7.9s (595 modules)
+ GET / 200 in 8487ms

--- a/src/app/footer.jsx
+++ b/src/app/footer.jsx
@@ -2,11 +2,18 @@ import React from "react";
 
 function Footer() {
   return (
-    <footer className="flex px-6  justify-between md:justify-center items-center w-full gap-12 absolute bottom-0 h-12 text-xs font-medium">
-      <p>©2024 Giorgio Paoloni™</p>
-      <ul className="flex gap-3">
-        <li>Privacy Policy</li>
-      </ul>
+    <footer className="bg-white py-16 px-6 relative mt-16">
+      <div className="max-w-7xl mx-auto flex flex-col items-center">
+        <div className="text-2xl font-serif italic mb-10 text-gallery-dark">Giorgio Paoloni</div>
+        <div className="flex space-x-8 mb-12">
+          <a className="text-gray-400 hover:text-gallery-dark transition-colors uppercase text-sm tracking-widest" href="#">Instagram</a>
+          <a className="text-gray-400 hover:text-gallery-dark transition-colors uppercase text-sm tracking-widest" href="#">Behance</a>
+          <a className="text-gray-400 hover:text-gallery-dark transition-colors uppercase text-sm tracking-widest" href="#">Vimeo</a>
+        </div>
+        <div className="text-[10px] uppercase tracking-widest text-gray-400 text-center">
+          © {new Date().getFullYear()} GIORGIO PAOLONI PHOTOGRAPHY. ALL RIGHTS RESERVED.
+        </div>
+      </div>
     </footer>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,3 +5,15 @@
 img {
   @apply animate-scale-up-center;
 }
+
+.image-hover-container:hover .image-overlay {
+  opacity: 1;
+}
+
+.image-hover-container img {
+  transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.image-hover-container:hover img {
+  transform: scale(1.05);
+}

--- a/src/app/header.jsx
+++ b/src/app/header.jsx
@@ -9,98 +9,88 @@ function Header() {
   const [isNavOpen, setIsNavOpen] = useState(false);
 
   return (
-    <>
-      {/* Navbar per versioni desktop */}
-      <div className="flex items-center justify-between p-7 mt-4 h-10 w-11/12 border-2 border-[#2F3645] border-opacity-60 rounded-3xl bg-[#e8e6e3] bg-opacity-90">
-        <Link
-          href="https://www.instagram.com/_jojifilm_/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <FaInstagram className="scale-150 cursor-pointer hover:opacity-45 transition-all" />
-        </Link>
-        <button
-          aria-expanded={isNavOpen}
-          className="scale-150 cursor-pointer h-16 md:hidden hover:opacity-45 transition-all"
-          onClick={() => setIsNavOpen((prev) => !prev)}
-        >
-          <RxHamburgerMenu />
-        </button>
-        <div className="hidden md:flex space-x-4 gap-5">
-          <Link
-            href="/"
-            className="hover:text-gray-700 hover:scale-110 transition-all"
-          >
-            Home
-          </Link>
-          <Link
-            href="/about"
-            className="hover:text-gray-700 hover:scale-110 transition-all"
-          >
-            About
-          </Link>
-          <Link
-            href="/portfolio"
-            className="hover:text-gray-700 hover:scale-110 transition-all"
-          >
-            Portfolio
-          </Link>
-          <Link
-            href="/blog"
-            className="hover:text-gray-700 hover:scale-110 transition-all"
-          >
-            Blog
+    <header className="fixed w-full top-0 z-50 bg-white/80 backdrop-blur-sm border-b border-gray-100">
+      <nav className="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
+        {/* Logo/Brand */}
+        <div className="text-2xl font-serif tracking-tighter">
+          <Link href="/" className="hover:opacity-70 transition-opacity">
+            Giorgio Paoloni
           </Link>
         </div>
-      </div>
 
-      <div
-        className={`fixed inset-0 bg-[#EEEDEB] flex flex-col justify-center items-center z-50 transform transition-transform duration-300 md:hidden ${
-          isNavOpen ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        <div
-          className="absolute top-0 flex items-center justify-between px-7 mt-4 w-full h-10"
-          onClick={() => setIsNavOpen(false)}
-        >
+        {/* Navigation Links (Desktop) */}
+        <div className="hidden md:flex items-center space-x-8 text-sm uppercase tracking-widest font-light">
+          <Link href="/" className="hover:text-gray-500 transition-colors">Home</Link>
+          <Link href="/portfolio" className="hover:text-gray-500 transition-colors">Portfolio</Link>
+          <Link href="/about" className="hover:text-gray-500 transition-colors">About</Link>
+          <Link href="/blog" className="hover:text-gray-500 transition-colors">Blog</Link>
+        </div>
+
+        {/* Social Icon & Mobile Menu Toggle */}
+        <div className="flex items-center space-x-4">
           <Link
             href="https://www.instagram.com/_jojifilm_/"
             rel="noopener noreferrer"
             target="_blank"
+            className="p-2 border border-gray-200 rounded-full hover:bg-gray-50 transition-colors"
           >
-            <FaInstagram className="scale-150 cursor-pointer" />
+            <FaInstagram className="w-5 h-5 text-gallery-dark" />
           </Link>
           <button
-            className="scale-150 cursor-pointer"
-            onClick={() => setIsNavOpen(false)}
+            aria-expanded={isNavOpen}
+            className="md:hidden p-2 text-gallery-dark cursor-pointer hover:opacity-70 transition-all"
+            onClick={() => setIsNavOpen((prev) => !prev)}
           >
-            <RxCross2 />
+            <RxHamburgerMenu className="w-6 h-6" />
           </button>
         </div>
-        <ul className="flex flex-col items-center justify-center min-h-[250px] text-2xl">
-          <li className="border-b border-gray-400 my-8 uppercase">
-            <Link href="/" onClick={() => setIsNavOpen(false)}>
+      </nav>
+
+      {/* Mobile Menu Drawer */}
+      <div
+        className={`fixed inset-0 bg-gallery-white flex flex-col justify-center items-center z-50 transform transition-transform duration-300 md:hidden ${
+          isNavOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div
+          className="absolute top-0 w-full h-20 flex items-center justify-between px-6 border-b border-gray-100"
+        >
+          <div className="text-2xl font-serif tracking-tighter">
+            <Link href="/" onClick={() => setIsNavOpen(false)} className="hover:opacity-70 transition-opacity">
+              Giorgio Paoloni
+            </Link>
+          </div>
+          <button
+            className="p-2 text-gallery-dark cursor-pointer hover:opacity-70 transition-all"
+            onClick={() => setIsNavOpen(false)}
+          >
+            <RxCross2 className="w-6 h-6" />
+          </button>
+        </div>
+        <ul className="flex flex-col items-center justify-center space-y-8 text-xl uppercase tracking-widest font-light">
+          <li>
+            <Link href="/" onClick={() => setIsNavOpen(false)} className="hover:text-gray-500 transition-colors">
               Home
             </Link>
           </li>
-          <li className="border-b border-gray-400 my-8 uppercase">
-            <Link href="/about" onClick={() => setIsNavOpen(false)}>
-              About
-            </Link>
-          </li>
-          <li className="border-b border-gray-400 my-8 uppercase">
-            <Link href="/portfolio" onClick={() => setIsNavOpen(false)}>
+          <li>
+            <Link href="/portfolio" onClick={() => setIsNavOpen(false)} className="hover:text-gray-500 transition-colors">
               Portfolio
             </Link>
           </li>
-          <li className="border-b border-gray-400 my-8 uppercase">
-            <Link href="/blog" onClick={() => setIsNavOpen(false)}>
+          <li>
+            <Link href="/about" onClick={() => setIsNavOpen(false)} className="hover:text-gray-500 transition-colors">
+              About
+            </Link>
+          </li>
+          <li>
+            <Link href="/blog" onClick={() => setIsNavOpen(false)} className="hover:text-gray-500 transition-colors">
               Blog
             </Link>
           </li>
         </ul>
       </div>
-    </>
+    </header>
   );
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,20 @@
 import type { Metadata } from "next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { JetBrains_Mono } from "next/font/google";
+import { Inter, Playfair_Display } from "next/font/google";
 import Header from "@/app/header";
 import Footer from "@/app/footer";
 import "./globals.css";
 
-const jetBrainsMono = JetBrains_Mono({
-  weight: "400", // Puoi specificare il peso (400 per Regular)
-  subsets: ["latin"], // Puoi specificare i subset necessari
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+});
+
+const playfairDisplay = Playfair_Display({
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+  weight: ["400", "700"],
+  variable: "--font-playfair",
 });
 
 export const metadata: Metadata = {
@@ -24,9 +31,9 @@ export default function RootLayout({
     <>
       <html
         lang="en"
-        className="relative min-h-screen bg-[#EEEDEB] text-[#2F3645]"
+        className={`relative min-h-screen bg-gallery-white text-gallery-dark font-sans antialiased ${inter.variable} ${playfairDisplay.variable}`}
       >
-        <body className={jetBrainsMono.className}>
+        <body className={inter.className}>
           <div className="w-full flex justify-center">
             <Header />
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,83 @@
-import Image from "next/image";
+import PortfolioCard from "@/components/portfoliocard";
+import fs from 'fs/promises';
+import path from 'path';
+import MasonryWrapper from '@/components/MasonryWrapper';
 
-export default function Home() {
+interface ImageDetail {
+  url: string;
+  blurDataURL: string;
+}
+
+interface ImageUrlsData {
+  [folderKey: string]: ImageDetail[];
+}
+
+export default async function Home() {
+  let imageData: ImageUrlsData = {};
+  const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
+
+  try {
+    const fileContent = await fs.readFile(jsonFilePath, 'utf-8');
+    imageData = JSON.parse(fileContent) as ImageUrlsData;
+  } catch (error) {
+    console.error("Failed to read or parse image_urls.json:", error);
+  }
+
+  const portfolioFolders = Object.entries(imageData)
+    .filter(([folderKey]) => folderKey.startsWith("Portfolio/"))
+    .map(([folderKey, imageObjects]) => {
+      if (imageObjects && imageObjects.length > 0 && imageObjects[0] && imageObjects[0].url) {
+        return {
+          folderKey,
+          coverImageUrl: imageObjects[0].url,
+          blurDataURL: imageObjects[0].blurDataURL || "", // Provide a fallback for blurDataURL if it's missing
+        };
+      }
+      return { folderKey, coverImageUrl: undefined, blurDataURL: undefined };
+    })
+    .filter(item => item.coverImageUrl !== undefined); // Ensure only items with a cover image proceed
+
+  const breakpointColumnsObj = {
+    default: 3,
+    900: 2,
+    750: 1
+  };
+
   return (
-    <div>
-      <h1 className="text-4xl font-extrabold text-center italic pt-16 pb-16">
-        Hi i’m Giorgio
-      </h1>
-      <div className="flex flex-col justify-center items-center">
-        <Image
-          src="https://d321io5nxf2wuu.cloudfront.net/Assets/Hero_picture_mobile.webp"
-          className="rounded-lg"
-          width={310}
-          height={310}
-          alt="Picture of the author"
-          priority={true}
-          placeholder="blur"
-          blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXz/2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz/wAARCACUAJQDASIAAhEBAxEB/8QAGgABAAMBAQEAAAAAAAAAAAAAAAEDBAIFBv/EAB0QAQADAQEBAQEBAAAAAAAAAAABERICEwNRYQT/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8A+rEWWCRFlgkQWCRACUuUgkQAkQAlAAAgEiAHNluLLB3Zbiywd2W4ssHdptxZYO7Lc2WDuy3Nlg6stFlgmxzZYOkIssEiLAUaNK9GgWaNK9GgW2Wq0nQLbLV6NAttNqrTYLLTau02Duy3Flg7stxZYO7LcWWDuxxYDHo0p0aBdpOlGk6BdpOlOk6BdpOlMdJjoF2k6Ux060C3SdKtJ0C2y1Wk6BZZavRoFllq9GgWWK9APN2nbPtOwX7Ttn2nYNGkx0z7THYNEdOo6Z46THQNEdJjpRHTqOgXx0nSiOk6Bfo0p0nQLtGlOk6Bbo0q0aBboVaAeRs2z7TsGjads207BpjtMds8dpjsGmO3Uds0duo7BpjtMds8dpjsGmOk6Z47TsGjSdM+07BfpOlGzYL9GlG07BdoU7AeJtO2badg07THbLtMdg1R26jtljtMdg1R26jtljt1HYNUduo7ZY7THYNUduo7ZY7THYNW07Ztmwadp2zbTsGjZtn2bBo2M+wHh+h6Me+jcg2+ifRi9JPToG6Po6j6MHrKfaQb4+jqPo8+Pu6j7g9CPo6j6PPj/RH66j7x+g3x9HUfRgj7x+uo+39Bu9E+jDH2/qfb+g3eh6MXr/U+v9Bs9E+jH6nqDZ6DH6gPKAAAAAAAAAATc/qAE6n9lO+v1yA79Ov09ev1wAs9ej26VgLPboVgAAAAAAAAAAAAAAAAAAAAP//Z"
-        />
-        <h2 className="text-2xl font-semibold mt-4 text-center">
-          {'"Moments Made Eternal"'}
-        </h2>
-        <span className="text-md font-medium text-gray-500 text-center leading-9">
-          <p className="tracking-wide ">Turn fleeting moments</p>
-          <p className="tracking-wide">into everlasting</p>
-          <p className="tracking-wide">memories.</p>
-        </span>
-      </div>
+    <div className="pt-20">
+      <section className="py-24 px-6 bg-white text-center">
+        <div className="max-w-2xl mx-auto">
+          <h2 className="text-3xl md:text-4xl font-serif mb-8 italic">Dive into my world</h2>
+          <p className="text-gray-500 leading-relaxed font-light">
+            A curated selection of moments frozen in time, where the raw power of nature meets the delicate silence of the wilderness. From deep mossy forests to sun-drenched canyon rivers.
+          </p>
+        </div>
+      </section>
+
+      <section className="pb-24 px-6 md:px-12 max-w-[1600px] mx-auto" id="portfolio">
+        {portfolioFolders.length > 0 ? (
+          <MasonryWrapper
+            breakpointCols={breakpointColumnsObj}
+            className="flex w-auto gap-8"
+            columnClassName="bg-clip-padding flex flex-col gap-8"
+          >
+            {portfolioFolders.map(({ folderKey, coverImageUrl, blurDataURL }, index) => {
+              if (!coverImageUrl) return null;
+              return (
+                <div key={folderKey || index}>
+                  <PortfolioCard
+                    folderKey={folderKey}
+                    coverImageUrl={coverImageUrl}
+                    blurDataURL={blurDataURL || ""}
+                  />
+                </div>
+              );
+            })}
+          </MasonryWrapper>
+        ) : (
+          <p className="text-center text-red-500">Could not load portfolio items. Please try again later.</p>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/components/portfoliocard.tsx
+++ b/src/components/portfoliocard.tsx
@@ -22,20 +22,24 @@ const PortfolioCard = ({ folderKey, coverImageUrl, blurDataURL }: PortfolioCardP
 
   return (
     <Link href={href}>
-      <div className="relative flex flex-col w-full text-center border-b-2 border-[#2F3645]">
-        <Image
-          src={coverImageUrl}
-          alt={altText}
-          width={500}
-          height={500}
-          placeholder="blur" // Ensure placeholder is still "blur"
-          className="rounded-t-lg hover:opacity-100 opacity-75 transition-all duration-300 group-hover:scale-105 ease-in-out w-full h-auto"
-          blurDataURL={blurDataURL} // Use the passed blurDataURL prop
-        />
-        <div className="absolute bottom-0 w-full h-auto bg-gradient-to-t from-black/80 to-transparent p-4 flex justify-center items-center">
-          <h2 className="text-2xl md:text-3xl font-bold z-10">
-            {altText}
-          </h2>
+      <div className="space-y-4 group">
+        <div className="relative overflow-hidden bg-gray-100 image-hover-container">
+          <Image
+            src={coverImageUrl}
+            alt={altText}
+            width={500}
+            height={500}
+            placeholder="blur"
+            className="w-full h-auto object-cover"
+            blurDataURL={blurDataURL}
+          />
+          <div className="image-overlay absolute inset-0 bg-black/40 opacity-0 transition-opacity duration-500 flex items-center justify-center">
+            <span className="text-white text-sm tracking-widest uppercase font-light">View Collection</span>
+          </div>
+        </div>
+        <div className="flex justify-between items-end px-2">
+          <h3 className="font-serif italic text-xl text-gallery-dark">{altText}</h3>
+          <span className="text-[10px] tracking-widest uppercase text-gray-400">Series</span>
         </div>
       </div>
     </Link>

--- a/src/utils/awsS3UtilityFunctions.ts
+++ b/src/utils/awsS3UtilityFunctions.ts
@@ -32,16 +32,17 @@ export const getFoldersInFolder = unstable_cache(
 
     const command = new ListObjectsV2Command(params);
 
-  try {
-    const response = await getClient().send(command);
-    return response.Contents?.filter(
-      (content) =>
-        content.Key?.split("/").length === prefix.split("/").length + 1 &&
-        content.Size === 0
-    );
-  } catch (error) {
-    console.error("Error fetching objects:", error);
-    throw error;
+    try {
+      const response = await getClient().send(command);
+      return response.Contents?.filter(
+        (content) =>
+          content.Key?.split("/").length === prefix.split("/").length + 1 &&
+          content.Size === 0
+      );
+    } catch (error) {
+      console.error("Error fetching objects:", error);
+      throw error;
+    }
   }
 );
 
@@ -54,12 +55,13 @@ export const getFirstImageFromFolder = unstable_cache(
     };
     const command = new ListObjectsV2Command(params);
 
-  try {
-    const response = await getClient().send(command);
-    return response.Contents?.find((content) => content.Size !== 0);
-  } catch (error) {
-    console.error("Error fetching objects:", error);
-    throw error;
+    try {
+      const response = await getClient().send(command);
+      return response.Contents?.find((content) => content.Size !== 0);
+    } catch (error) {
+      console.error("Error fetching objects:", error);
+      throw error;
+    }
   }
 );
 
@@ -70,16 +72,17 @@ export const getImagesFromFolder = unstable_cache(
       Prefix: prefix,
     };
 
-  const command = new ListObjectsV2Command(params);
-  try {
-    const response = await getClient().send(command);
-    return response.Contents?.filter(
-      (content) =>
-        content.Key?.split("/").length === prefix.split("/").length + 1 &&
-        content.Size != 0
-    );
-  } catch (error) {
-    console.error("Error fetching objects:", error);
-    throw error;
+    const command = new ListObjectsV2Command(params);
+    try {
+      const response = await getClient().send(command);
+      return response.Contents?.filter(
+        (content) =>
+          content.Key?.split("/").length === prefix.split("/").length + 1 &&
+          content.Size != 0
+      );
+    } catch (error) {
+      console.error("Error fetching objects:", error);
+      throw error;
+    }
   }
 );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,15 @@ const config: Config = {
 
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)'],
+        serif: ['var(--font-playfair)'],
+      },
+      colors: {
+        'gallery-white': '#fdfdfd',
+        'gallery-gray': '#f2f2f2',
+        'gallery-dark': '#1a1a1a',
+      },
       animation: {
         "scale-up-center":
           "scale-up-center 0.25s cubic-bezier(0.390, 0.575, 0.565, 1.000)   both",


### PR DESCRIPTION
Implemented the new clean, editorial-style layout requested. The homepage now skips the large hero banner and goes straight into the "Dive into my world" introduction and the portfolio grid. The colors, typography, and hover interactions match the provided HTML reference design. The brand name has been changed from "Studio.Nature" to "Giorgio Paoloni", and the "The eye behind the lens" section has been successfully removed while preserving the footer.

---
*PR created automatically by Jules for task [12196762398023364899](https://jules.google.com/task/12196762398023364899) started by @Giorey01*