### PR TITLE
fix: Build script JSON parsing and syntax errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' ./scripts/fetch-image-urls.ts && next build",
+    "build": "ts-node --compiler-options \"{\\\"module\\\":\\\"CommonJS\\\"}\" ./scripts/fetch-image-urls.ts && next build",
     "start": "next start",
     "lint": "next lint"
   },
@@ -23,6 +23,7 @@
     "ts-node": "^10.9.2"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.10",
     "@types/node": "^20.17.50",
     "@types/nodemailer": "^6.4.17",
     "@types/react": "^18",

--- a/src/utils/awsS3UtilityFunctions.test.ts
+++ b/src/utils/awsS3UtilityFunctions.test.ts
@@ -21,7 +21,7 @@ mock.module("@aws-sdk/client-s3", () => {
 });
 
 // Re-import to ensure it uses the mock
-import { getFirstImageFromFolder, getImagesFromFolder } from "./awsS3UtilityFunctions";
+import { getFoldersInFolder, getFirstImageFromFolder, getImagesFromFolder } from "./awsS3UtilityFunctions";
 
 describe("getImagesFromFolder", () => {
   beforeEach(() => {

--- a/src/utils/awsS3UtilityFunctions.ts
+++ b/src/utils/awsS3UtilityFunctions.ts
@@ -44,7 +44,7 @@ export const getFoldersInFolder = unstable_cache(
       throw error;
     }
   }
-});
+);
 
 export const getFirstImageFromFolder = unstable_cache(
   async (prefix: string) => {
@@ -63,7 +63,7 @@ export const getFirstImageFromFolder = unstable_cache(
       throw error;
     }
   }
-});
+);
 
 export const getImagesFromFolder = unstable_cache(
   async (prefix: string) => {
@@ -85,4 +85,4 @@ export const getImagesFromFolder = unstable_cache(
       throw error;
     }
   }
-});
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "test-setup.ts", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
This fixes the issue where `pnpm run build` or `npm run build` failed on Windows due to a JSON parsing error in the `ts-node --compiler-options` argument string in `package.json`. It also fixes multiple syntax errors in `src/utils/awsS3UtilityFunctions.ts` and updates `tsconfig.json` to ignore test files during the Next.js production build, ensuring a successful build pipeline.

---
*PR created automatically by Jules for task [9614409060240210265](https://jules.google.com/task/9614409060240210265) started by @Giorey01*