### PR TITLE
fix: Correct mobile menu drawer fixed positioning constrained by backdrop-filter

### DIFF
--- a/src/app/header.jsx
+++ b/src/app/header.jsx
@@ -21,6 +21,7 @@ function Header() {
   }, [isNavOpen]);
 
   return (
+    <>
     <header className="fixed w-full top-0 z-50 bg-white/80 backdrop-blur-sm border-b border-gray-100">
       <nav className="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
         {/* Logo/Brand */}
@@ -57,6 +58,7 @@ function Header() {
           </button>
         </div>
       </nav>
+    </header>
 
       {/* Mobile Menu Drawer */}
       <div
@@ -102,7 +104,7 @@ function Header() {
           </li>
         </ul>
       </div>
-    </header>
+    </>
   );
 }
 


### PR DESCRIPTION
This PR addresses an issue where the mobile navigation drawer was constrained to the top navigation bar's height instead of covering the entire viewport. 

The bug was caused by a CSS containing block issue: the `<header>` component applies a `backdrop-filter` via Tailwind's `backdrop-blur-sm` utility. According to CSS specifications, `backdrop-filter` creates a new containing block for absolutely and fixed positioned descendants, which trapped the `fixed inset-0` mobile menu drawer inside the header. 

By moving the drawer out of the `<header>` tag and rendering it as a sibling via a React fragment, the drawer now correctly references the viewport for its `fixed` positioning.

---
*PR created automatically by Jules for task [11568189314824331025](https://jules.google.com/task/11568189314824331025) started by @Giorey01*