### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent resource exhaustion in benchmark API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [MEDIUM] Prevent resource exhaustion in benchmark API
+**Vulnerability:** The `/api/benchmark` endpoint was exposed in production, allowing unauthenticated users to trigger expensive S3 operations (list objects). This could lead to a Denial of Wallet (DoW) or Denial of Service (DoS) attack.
+**Learning:** Next.js API routes that perform heavy or costly operations, especially those created for testing or benchmarking purposes, must be protected or removed before production deployment.
+**Prevention:** Always restrict access to such endpoints using an environment check (`if (process.env.NODE_ENV !== 'development') { return NextResponse.json({ error: 'Not Found' }, { status: 404 }); }`) or robust authentication.

--- a/src/app/api/benchmark/route.ts
+++ b/src/app/api/benchmark/route.ts
@@ -4,6 +4,10 @@ import { getFoldersInFolder, getFirstImageFromFolder, getImagesFromFolder } from
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  }
+
   const start1 = performance.now();
   try {
     await getFoldersInFolder('Portfolio/');


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The `/api/benchmark` endpoint, which performs expensive S3 list object operations, was publicly accessible in production. 
**🎯 Impact:** An unauthenticated attacker could repeatedly call this endpoint, causing unnecessary AWS S3 API charges (Denial of Wallet) and server resource exhaustion (DoS).
**🔧 Fix:** Added a strict environment check at the beginning of the `GET` handler. If `process.env.NODE_ENV !== 'development'`, the endpoint immediately returns a 404 Not Found response.
**✅ Verification:** Run the application in production mode (`npm run build` then `npm start`) and attempt to visit `/api/benchmark`. It will return a 404. Run in development mode (`npm run dev`) and it will execute the benchmark.

---
*PR created automatically by Jules for task [6649976839904312575](https://jules.google.com/task/6649976839904312575) started by @Giorey01*