### PR TITLE
Update collage styling and apply to blog page

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,17 +1,87 @@
 import React from "react";
 import getPostMetadata from "@/utils/getPostMetadata";
-import PostCard from "../../components/postcard";
+import ScrapbookCard from "@/components/ScrapbookCard";
+import { PaperTexture } from "@/components/ScrapbookDecorations";
 
 async function Blog() {
   const postMetadata = await getPostMetadata("posts");
 
+  const collageStyles = [
+    { rotation: "rotate-[-3deg]", zIndex: 10, tapePosition: "top" as const, stampType: "none" as const, marginTop: "mt-0" },
+    { rotation: "rotate-[4deg]", zIndex: 20, tapePosition: "corners" as const, stampType: "none" as const, marginTop: "md:mt-24 mt-12" },
+    { rotation: "rotate-[-1deg]", zIndex: 5, tapePosition: "bottom" as const, stampType: "scribble" as const, marginTop: "md:mt-8 mt-4" },
+    { rotation: "rotate-[2deg]", zIndex: 30, tapePosition: "top" as const, stampType: "none" as const, marginTop: "md:-mt-16 -mt-8" },
+    { rotation: "rotate-[-5deg]", zIndex: 15, tapePosition: "corners" as const, stampType: "none" as const, marginTop: "md:mt-32 mt-16" },
+    { rotation: "rotate-[1deg]", zIndex: 25, tapePosition: "bottom" as const, stampType: "none" as const, marginTop: "md:-mt-4 mt-0" },
+  ];
+
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {postMetadata.map((post, postIndex) => {
-          return <PostCard key={postIndex} post={post} />;
-        })}
-      </div>
+    <div className="min-h-screen relative overflow-hidden bg-[#fcfbf8]">
+      {/* Texture della carta in overlay, mixata con il colore di fondo */}
+      <PaperTexture className="fixed inset-0 pointer-events-none z-0" />
+
+      {/* Hero Section: Tipografia Gigante ed Editoriale */}
+      <section className="relative z-10 pt-24 md:pt-40 px-6 max-w-[1800px] mx-auto overflow-hidden">
+        {/* Cerchio scarabocchiato enorme per riempire lo spazio bianco */}
+        <div className="absolute top-10 md:top-20 -left-20 w-[600px] h-[600px] opacity-10 pointer-events-none rounded-full border-[3px] border-dashed border-gray-600 rotate-12" />
+
+        <div className="relative z-20 flex flex-col justify-center items-start md:items-center text-left md:text-center w-full">
+          {/* Titolo Principale in stile magazine/giornale */}
+          <h1 className="font-serif italic text-6xl md:text-[120px] lg:text-[160px] xl:text-[200px] leading-[0.8] tracking-tighter text-[#1a1a1a] uppercase select-none">
+            Journal
+            <br />
+            <span className="font-sans font-bold tracking-widest text-4xl md:text-[60px] lg:text-[90px] xl:text-[120px] not-italic ml-4 md:ml-20">Archive</span>
+          </h1>
+
+          <div className="mt-8 md:mt-12 md:max-w-3xl md:mx-auto md:text-center flex flex-col items-start md:items-center">
+            <p className="font-serif italic text-2xl md:text-4xl text-gray-600 mb-6 border-b border-gray-300 pb-4 inline-block">
+              Notes & Thoughts
+            </p>
+            <p className="font-sans text-xs md:text-sm uppercase tracking-[0.3em] font-semibold text-[#1a1a1a] max-w-lg leading-relaxed mix-blend-multiply">
+              A collection of thoughts, stories, and experiences. Words that shape my journey and reflections on design, life, and the world around us.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Sezione Blog: Layout Collage/Scrapbook Libero */}
+      <section className="relative z-20 pb-32 pt-20 px-6 md:px-16 max-w-[1600px] mx-auto" id="blog-posts">
+        {postMetadata.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12 md:gap-x-16 lg:gap-x-24 place-items-center">
+            {postMetadata.map((post, index) => {
+              if (!post.thumbnail) return null;
+
+              // Applica ciclicamente gli stili di rotazione e margine per l'effetto scrapbook
+              const styleProps = collageStyles[index % collageStyles.length];
+              const title = post.title.replace(/_/g, " ");
+
+              return (
+                <div key={post.slug || index} className="w-full max-w-[500px] relative">
+                  <ScrapbookCard
+                    title={title}
+                    href={`/blog/${post.slug}`}
+                    coverImageUrl={post.thumbnail}
+                    blurDataURL=""
+                    rotation={styleProps.rotation}
+                    zIndex={styleProps.zIndex}
+                    tapePosition={styleProps.tapePosition}
+                    stampType={styleProps.stampType}
+                    marginTop={styleProps.marginTop}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-center text-red-500 font-mono text-sm uppercase">Journal empty. Connection lost.</p>
+        )}
+      </section>
+
+      {/* Footer Editoriale della Homepage (opzionale, per chiudere la pagina) */}
+      <footer className="relative z-10 border-t-2 border-dashed border-gray-300 mx-6 md:mx-16 mt-16 py-8 flex justify-between items-center text-[#1a1a1a]">
+        <span className="font-serif italic text-xl">End of Selection</span>
+        <span className="font-sans uppercase text-[10px] tracking-[0.3em] font-bold">Vol. 01 / Current Year</span>
+      </footer>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,11 +37,11 @@ export default async function Home() {
   // Per creare un effetto "caotico" ma controllato, definiamo un array di stili preimpostati (rotazioni, margini, z-index).
   // Li applicheremo in ciclo (modulo) agli elementi per non avere un collage completamente randomico e ingestibile.
   const collageStyles = [
-    { rotation: "rotate-[-3deg]", zIndex: 10, tapePosition: "top" as const, stampType: "postage" as const, marginTop: "mt-0" },
+    { rotation: "rotate-[-3deg]", zIndex: 10, tapePosition: "top" as const, stampType: "none" as const, marginTop: "mt-0" },
     { rotation: "rotate-[4deg]", zIndex: 20, tapePosition: "corners" as const, stampType: "none" as const, marginTop: "md:mt-24 mt-12" },
     { rotation: "rotate-[-1deg]", zIndex: 5, tapePosition: "bottom" as const, stampType: "scribble" as const, marginTop: "md:mt-8 mt-4" },
-    { rotation: "rotate-[2deg]", zIndex: 30, tapePosition: "top" as const, stampType: "approval" as const, marginTop: "md:-mt-16 -mt-8" },
-    { rotation: "rotate-[-5deg]", zIndex: 15, tapePosition: "corners" as const, stampType: "postage" as const, marginTop: "md:mt-32 mt-16" },
+    { rotation: "rotate-[2deg]", zIndex: 30, tapePosition: "top" as const, stampType: "none" as const, marginTop: "md:-mt-16 -mt-8" },
+    { rotation: "rotate-[-5deg]", zIndex: 15, tapePosition: "corners" as const, stampType: "none" as const, marginTop: "md:mt-32 mt-16" },
     { rotation: "rotate-[1deg]", zIndex: 25, tapePosition: "bottom" as const, stampType: "none" as const, marginTop: "md:-mt-4 mt-0" },
   ];
 

--- a/src/components/ScrapbookCard.tsx
+++ b/src/components/ScrapbookCard.tsx
@@ -6,7 +6,7 @@ import React from "react";
 
 // Definisce le Props (dati) per la singola card in stile scrapbook
 interface ScrapbookCardProps {
-  folderKey: string;
+  folderKey?: string;
   coverImageUrl: string;
   blurDataURL: string;
   rotation: string;      // Gradi di rotazione (es. "-rotate-2", "rotate-3")
@@ -14,6 +14,8 @@ interface ScrapbookCardProps {
   tapePosition: "top" | "bottom" | "corners"; // Dove mettere lo scotch
   stampType?: "postage" | "approval" | "scribble" | "none"; // Che timbro aggiungere
   marginTop?: string;    // Margine superiore per "sfalsare" le immagini
+  title?: string;
+  href?: string;
 }
 
 const ScrapbookCard = ({
@@ -24,15 +26,19 @@ const ScrapbookCard = ({
   zIndex,
   tapePosition,
   stampType = "none",
-  marginTop = "mt-0"
+  marginTop = "mt-0",
+  title,
+  href: customHref
 }: ScrapbookCardProps) => {
-  const altText = folderKey.split('/').filter(Boolean).pop() || "Portfolio image";
+  const altText = title || (folderKey ? folderKey.split('/').filter(Boolean).pop() : "Portfolio image") || "Portfolio image";
   const slug = folderKey
-    .toLowerCase()
-    .replace(/^portfolio\//, "")
-    .replace(/\/$/, "");
+    ? folderKey
+        .toLowerCase()
+        .replace(/^portfolio\//, "")
+        .replace(/\/$/, "")
+    : "";
 
-  const href = `/portfolio/${slug}`;
+  const href = customHref || `/portfolio/${slug}`;
 
   return (
     <Link href={href} className="block group w-full outline-none">
@@ -69,9 +75,9 @@ const ScrapbookCard = ({
               alt={altText}
               fill
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              placeholder="blur"
+              placeholder={blurDataURL ? "blur" : "empty"}
               className="object-cover grayscale-[0.2] contrast-125 group-hover:grayscale-0 transition-all duration-700"
-              blurDataURL={blurDataURL}
+              blurDataURL={blurDataURL || undefined}
             />
           </div>
 
@@ -81,7 +87,7 @@ const ScrapbookCard = ({
             <span className="font-sans text-[10px] md:text-xs tracking-[0.2em] uppercase text-gray-500 font-bold border-b border-gray-300 pb-1">Series</span>
           </div>
 
-          <PhotoLabel text={`FILE: ${slug.substring(0,6).toUpperCase()}`} className="-bottom-3 right-4 rotate-3" />
+          <PhotoLabel text={`FILE: ${altText.toUpperCase()}`} className="-bottom-3 right-4 rotate-3" />
         </div>
       </div>
     </Link>


### PR DESCRIPTION
This commit addresses the following:
1. Removes the "Selected" and "Archive Est 2024" stamps from the collages on the homepage.
2. Updates the `ScrapbookCard` component to ensure the portfolio section names (and blog titles) are displayed in full without truncation.
3. Completely rewrites the `/blog` page to match the homepage's aesthetic, rendering the blog posts as a scrapbook collage.

---
*PR created automatically by Jules for task [14918226139960137489](https://jules.google.com/task/14918226139960137489) started by @Giorey01*