### PR TITLE
Remove stickers and stamps from collages

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,36 @@
+
+> giorgio-paoloni-portfolio@0.1.0 dev
+> next dev
+
+  ▲ Next.js 14.2.3
+  - Local:        http://localhost:3000
+
+ ✓ Starting...
+ ✓ Ready in 2.8s
+ ○ Compiling / ...
+ ✓ Compiled / in 9.8s (591 modules)
+ GET / 200 in 10548ms
+TypeError: fetch failed
+    at node:internal/deps/undici/undici:14902:13
+    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+    at async fetchExternalImage (/app/node_modules/next/dist/server/image-optimizer.js:565:17)
+    at async DevServer.imageOptimizer (/app/node_modules/next/dist/server/next-server.js:650:48)
+    at async cacheEntry.imageResponseCache.get.incrementalCache (/app/node_modules/next/dist/server/next-server.js:182:65)
+    at async /app/node_modules/next/dist/server/response-cache/index.js:90:36
+    at async /app/node_modules/next/dist/lib/batcher.js:45:32 {
+  [cause]: Error: getaddrinfo EAI_AGAIN via.placeholder.com
+      at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)
+      at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:130:17) {
+    errno: -3001,
+    code: 'EAI_AGAIN',
+    syscall: 'getaddrinfo',
+    hostname: 'via.placeholder.com'
+  }
+}
+ ○ Compiling /_error ...
+ ✓ Compiled /about in 7.7s (791 modules)
+ ⚠ You have added a custom /_error page without a custom /404 page. This prevents the 404 page from being auto statically optimized.
+See here for info: https://nextjs.org/docs/messages/custom-error-no-custom-404
+ GET /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F800x600.png%3Ftext%3DMock%2BImage&w=640&q=75 500 in 8164ms
+ GET /_next/image?url=https%3A%2F%2Fvia.placeholder.com%2F800x600.png%3Ftext%3DMock%2BImage&w=640&q=75 500 in 7931ms
+ GET /about 200 in 4634ms

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import Image from "next/image";
 import { FaArrowDownLong } from "react-icons/fa6";
 import { isValidEmail } from "@/utils/validation"; // Funzione creata per controllare se l'email è scritta bene
-import { PaperTexture, TapePiece, PostageStamp, PhotoLabel } from "@/components/ScrapbookDecorations";
+import { PaperTexture, TapePiece } from "@/components/ScrapbookDecorations";
 
 function About() {
   // `useState` è un Hook di React che permette al componente di "ricordare" dei dati che cambiano nel tempo.
@@ -90,7 +90,6 @@ function About() {
           <div className="mb-8 relative transition-all duration-500 ease-out hover:scale-[1.02] rotate-[-2deg]">
             <div className="bg-[#fdfdfd] p-3 md:p-4 pb-12 md:pb-16 shadow-[0_8px_30px_rgb(0,0,0,0.12)] border border-gray-200 relative group-hover:shadow-[0_20px_40px_rgb(0,0,0,0.2)]">
               <TapePiece className="-top-4 left-1/2 -translate-x-1/2 rotate-[-2deg]" />
-              <PostageStamp className="-right-8 -top-8 rotate-12" />
 
               <div className="relative w-64 h-64 md:w-80 md:h-80 bg-gray-100 overflow-hidden">
                 <Image
@@ -102,8 +101,6 @@ function About() {
                   alt="Giorgio Paoloni"
                 />
               </div>
-
-              <PhotoLabel text="FILE: BIO" className="-bottom-3 right-4 rotate-3" />
             </div>
           </div>
 

--- a/src/components/ScrapbookCard.tsx
+++ b/src/components/ScrapbookCard.tsx
@@ -1,5 +1,5 @@
 // Importa i componenti decorativi per lo stile "Scrapbook" (diario fotografico/collage)
-import { TapePiece, PostageStamp, PhotoLabel, ApprovalStamp, ScribbleCircle } from "@/components/ScrapbookDecorations";
+import { TapePiece, ApprovalStamp, ScribbleCircle } from "@/components/ScrapbookDecorations";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
@@ -64,7 +64,6 @@ const ScrapbookCard = ({
           )}
 
           {/* Timbri decorativi */}
-          {stampType === "postage" && <PostageStamp className="-right-8 -top-8 rotate-12" />}
           {stampType === "approval" && <ApprovalStamp text="SELECTED" color="#1a1a1a" className="top-1/4 -left-6" />}
           {stampType === "scribble" && <ScribbleCircle className="-bottom-10 -right-6 scale-75" />}
 
@@ -86,8 +85,6 @@ const ScrapbookCard = ({
             <span className="font-serif italic text-xl md:text-2xl text-gallery-dark tracking-wide">{altText}</span>
             <span className="font-sans text-[10px] md:text-xs tracking-[0.2em] uppercase text-gray-500 font-bold border-b border-gray-300 pb-1">Series</span>
           </div>
-
-          <PhotoLabel text={`FILE: ${altText.toUpperCase()}`} className="-bottom-3 right-4 rotate-3" />
         </div>
       </div>
     </Link>


### PR DESCRIPTION
Removed `PostageStamp` and `PhotoLabel` components from `ScrapbookCard` and the About page collage to ensure a cleaner look without these specific decorations, as requested. Visually verified across both the homepage and the about page.

---
*PR created automatically by Jules for task [12179728303989034186](https://jules.google.com/task/12179728303989034186) started by @Giorey01*