### PR TITLE
Update blog styling and portfolio masonry gallery

### DIFF
--- a/src/app/blog/[slug]/markdownpage.css
+++ b/src/app/blog/[slug]/markdownpage.css
@@ -1,7 +1,8 @@
 .markdown-container {
+  font-family: var(--font-playfair), serif;
   font-size: 1.125rem;
   line-height: 1.8;
-  color: #374151;
+  color: #1a1a1a;
 }
 
 .markdown-container a {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -72,15 +72,8 @@ function BlogPage({ params }: BlogPageProps) {
 
   return (
     <main className="max-w-4xl mx-auto px-6 py-12">
-      <Link
-        href="/blog"
-        className="inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors mb-8 font-medium"
-      >
-        <FaArrowLeft className="mr-2" /> Torna al Blog
-      </Link>
-
       <header className="mb-12">
-        <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 mb-4 leading-tight">
+        <h1 className="text-4xl md:text-5xl font-serif text-gray-900 mb-4 leading-tight">
           {post.data.title.replace(/_/g, " ")}
         </h1>
         <div className="flex items-center text-gray-500 text-sm">
@@ -91,7 +84,7 @@ function BlogPage({ params }: BlogPageProps) {
       </header>
 
       {post.data.thumbnail && (
-        <div className="relative w-full aspect-video mb-12 rounded-2xl overflow-hidden shadow-lg">
+        <div className="relative w-full aspect-video mb-12 overflow-hidden shadow-lg">
           <Image
             src={post.data.thumbnail}
             alt={post.data.title}
@@ -102,7 +95,7 @@ function BlogPage({ params }: BlogPageProps) {
         </div>
       )}
 
-      <article className="markdown-container prose prose-lg max-w-none">
+      <article className="markdown-container prose prose-lg max-w-none font-serif text-gallery-dark">
         <Markdown
           options={{
             overrides: {
@@ -114,15 +107,15 @@ function BlogPage({ params }: BlogPageProps) {
                        <img
                         src={src}
                         alt={alt}
-                        className="rounded-xl shadow-md w-full h-auto"
+                        className="shadow-md w-full h-auto"
                       />
                     </div>
                     {alt && <p className="mt-3 text-sm text-gray-500 italic">{alt}</p>}
                   </div>
                 ),
               },
-              h1: { component: ({children}) => <h1 className="text-3xl font-bold mt-12 mb-6">{children}</h1> },
-              h2: { component: ({children}) => <h2 className="text-2xl font-bold mt-10 mb-5">{children}</h2> },
+              h1: { component: ({children}) => <h1 className="text-3xl font-serif font-bold mt-12 mb-6">{children}</h1> },
+              h2: { component: ({children}) => <h2 className="text-2xl font-serif font-bold mt-10 mb-5">{children}</h2> },
               p: { component: ({children}) => <p className="text-gray-700 leading-relaxed mb-6">{children}</p> },
               ul: { component: ({children}) => <ul className="list-disc ml-6 mb-6 space-y-2">{children}</ul> },
               li: { component: ({children}) => <li className="text-gray-700">{children}</li> },

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
+import Masonry from "react-masonry-css";
 // Importiamo le icone dalla libreria react-icons (si usano come normali componenti React)
 import { FiX, FiChevronLeft, FiChevronRight } from "react-icons/fi";
 
@@ -90,7 +91,11 @@ export default function ImageGallery({ images, slug }: ImageGalleryProps) {
         1. LA GRIGLIA DELLE IMMAGINI
         Mostra le immagini come miniature quadrate usando Tailwind CSS
       */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 md:gap-6">
+      <Masonry
+        breakpointCols={{ default: 4, 1024: 3, 768: 2, 640: 1 }}
+        className="flex w-auto -ml-4 md:-ml-6"
+        columnClassName="pl-4 md:pl-6 bg-clip-padding"
+      >
         {images.map((imageDetail, index) => {
           const altText = imageDetail.url.substring(imageDetail.url.lastIndexOf('/') + 1) || `Image ${index + 1} for ${slug}`;
           return (
@@ -99,14 +104,17 @@ export default function ImageGallery({ images, slug }: ImageGalleryProps) {
               // Quando l'utente clicca su una foto, cambiamo lo stato impostando l'indice cliccato.
               // Questo triggera un ri-rendering (refresh) e fa aprire il modale (isModalOpen diventa true).
               onClick={() => setSelectedIndex(index)}
-              className="relative w-full aspect-[4/3] overflow-hidden rounded-lg shadow-md cursor-pointer group"
+              className="relative w-full overflow-hidden mb-4 md:mb-6 rounded-lg shadow-md cursor-pointer group"
             >
               <Image
                 src={imageDetail.url}
                 alt={altText}
-                fill // fill richiede che il div contenitore abbia position: relative
+                width={0}
+                height={0}
+                sizes="100vw"
+                style={{ width: '100%', height: 'auto' }}
                 // group-hover applica un effetto di scale quando si passa col mouse sull'intero contenitore
-                className="object-cover w-full h-full rounded-md transition-transform duration-300 group-hover:scale-105"
+                className="object-cover w-full h-auto rounded-md transition-transform duration-300 group-hover:scale-105"
                 placeholder="blur"
                 blurDataURL={imageDetail.blurDataURL}
               />
@@ -115,7 +123,7 @@ export default function ImageGallery({ images, slug }: ImageGalleryProps) {
             </div>
           );
         })}
-      </div>
+      </Masonry>
 
       {/*
         2. IL MODALE CAROSELLO A SCHERMO INTERO


### PR DESCRIPTION
This PR implements several styling updates to match the user's design requests:
1. Blog post pages now follow the editorial, consistent serif font.
2. The "torna al blog" link has been removed.
3. Blog post images are no longer rounded.
4. The portfolio gallery component has been refactored from a standard grid into a masonry layout.

---
*PR created automatically by Jules for task [7685509657769056029](https://jules.google.com/task/7685509657769056029) started by @Giorey01*