### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit bypass via IP spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `/api/benchmark` endpoint was exposed in production, allowing unauthenticated users to trigger expensive S3 operations (list objects). This could lead to a Denial of Wallet (DoW) or Denial of Service (DoS) attack.
 **Learning:** Next.js API routes that perform heavy or costly operations, especially those created for testing or benchmarking purposes, must be protected or removed before production deployment.
 **Prevention:** Always restrict access to such endpoints using an environment check (`if (process.env.NODE_ENV !== 'development') { return NextResponse.json({ error: 'Not Found' }, { status: 404 }); }`) or robust authentication.
+
+## 2024-05-24 - [HIGH] Fix rate limit bypass via IP spoofing
+**Vulnerability:** The contact form API (`/api/contact`) was using the *first* IP address from the `x-forwarded-for` header (`.split(',')[0]`) to identify clients for rate limiting. An attacker could trivially bypass the rate limiter by prepending a spoofed IP to the header, preventing their real IP from being blocked.
+**Learning:** In applications behind reverse proxies (like Vercel or Cloudflare), the reverse proxy appends the true client IP to the *end* of the `x-forwarded-for` chain. Any IPs before that can be freely spoofed by the client.
+**Prevention:** Always extract the *last* IP address from the `x-forwarded-for` chain (`.split(',').pop()`) when identifying the client's original IP address behind a trusted reverse proxy, or use a framework-provided secure method.

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -18,9 +18,10 @@ const MAX_MAP_SIZE = 1000; // Previene esaurimento memoria (DoS)
 export async function POST(request: Request) {
   try {
     // SECURITY: Rate limiting basato su IP per limitare le richieste
-    // Nota: x-forwarded-for puo' essere spoofato. Un rate limiter piu' robusto userebbe Redis e controllerebbe proxy fidati.
+    // Estraiamo l'ultimo IP da x-forwarded-for, che è tipicamente quello aggiunto dal proxy fidato (es. Vercel)
+    // Il primo IP può essere facilmente falsificato (spoofed) da un utente malintenzionato.
     // Per ora, limitiamo la dimensione della mappa per evitare OOM (Out Of Memory).
-    let ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() || request.headers.get('x-real-ip') || 'unknown';
+    let ip = request.headers.get('x-forwarded-for')?.split(',').pop()?.trim() || request.headers.get('x-real-ip') || 'unknown';
     const now = Date.now();
 
     // Evita crescita infinita della mappa


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The rate limiter in `/api/contact` was incorrectly extracting the *first* IP address from the `x-forwarded-for` header (`.split(',')[0]`). This allowed an attacker to completely bypass the rate limiter by simply prepending a spoofed IP to the header (e.g., `X-Forwarded-For: 1.2.3.4`).
🎯 **Impact:** An attacker could spam the contact form, exhaust the Ethereal test account or production SMTP server, or potentially trigger an Out-Of-Memory (OOM) error by overwhelming the in-memory map limit, leading to a Denial of Service (DoS).
🔧 **Fix:** Modified the logic to extract the *last* IP address from the `x-forwarded-for` chain (`.split(',').pop()`). In environments behind a reverse proxy (like Vercel), the true client IP is appended to the end of the chain by the trusted proxy, ensuring attackers cannot spoof it. Also documented the learning in `.jules/sentinel.md`.
✅ **Verification:** Ran `npm run lint` (0 errors) and `bun test` (all 16 tests passed). Verified that the correct IP extraction method is used.

---
*PR created automatically by Jules for task [12542980457231107560](https://jules.google.com/task/12542980457231107560) started by @Giorey01*