### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing security headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -45,6 +45,14 @@ const nextConfig = {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()", // Limita le API dei permessi disponibili
           },
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:;",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload",
+          },
         ],
       },
     ];


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add missing security headers

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `next.config.mjs` was missing `Content-Security-Policy` and `Strict-Transport-Security` headers. While basic headers like `X-Frame-Options` were present, CSP and HSTS are crucial for a defense-in-depth strategy.
🎯 **Impact:** Without a CSP, the application is more susceptible to Cross-Site Scripting (XSS) attacks. Without HSTS, the application is vulnerable to Man-in-the-Middle (MITM) downgrade attacks.
🔧 **Fix:** Added a permissive `Content-Security-Policy` (to support Next.js defaults without breaking functionality) and `Strict-Transport-Security` (`max-age=31536000; includeSubDomains; preload`) to the global `headers()` configuration in `next.config.mjs`.
✅ **Verification:** Verified that the application builds correctly (`npm run build`), passes linting (`npm run lint`), and passes tests (`bun test`).

---
*PR created automatically by Jules for task [11033098739641884037](https://jules.google.com/task/11033098739641884037) started by @Giorey01*