### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing security headers (CSP and HSTS)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Add missing security headers (CSP and HSTS)
+**Vulnerability:** The application was missing `Content-Security-Policy` (CSP) and `Strict-Transport-Security` (HSTS) headers. This leaves the application vulnerable to XSS and downgrade attacks.
+**Learning:** In Next.js applications, adding security headers to `next.config.mjs` provides a critical layer of defense in depth.
+**Prevention:** Always enforce a baseline permissive CSP and HSTS in `next.config.mjs` to protect against XSS and ensure secure connections.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -45,6 +45,14 @@ const nextConfig = {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()", // Limita le API dei permessi disponibili
           },
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src * blob: data:; font-src 'self' data:; connect-src *;", // Baseline permissiva CSP
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload", // Forza connessioni sicure (HSTS)
+          },
         ],
       },
     ];


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add missing security headers (CSP and HSTS)

🚨 Severity: MEDIUM
💡 Vulnerability: The application was missing Content-Security-Policy (CSP) and Strict-Transport-Security (HSTS) headers. This leaves the application vulnerable to XSS and downgrade attacks.
🎯 Impact: Attackers could potentially inject malicious scripts (XSS) or force a downgrade to an insecure HTTP connection.
🔧 Fix: Added a permissive baseline CSP and an HSTS header to `next.config.mjs` to provide defense in depth while maintaining existing functionality.
✅ Verification: Ran `npm run lint`, `npm run build`, and `bun test` to ensure the configuration change is valid and introduces no regressions.


---
*PR created automatically by Jules for task [13136512486048426674](https://jules.google.com/task/13136512486048426674) started by @Giorey01*