### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unhandled URIError Exception in Portfolio Dynamic Routing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-18 - [Unhandled URIError Exception in Dynamic Routes]
+**Vulnerability:** Calling `decodeURIComponent()` directly on dynamic route parameters (`params.slug`) without a `try...catch` block. This allows attackers to craft malformed URLs (e.g., `/portfolio/%C2`) that cause an unhandled `URIError`.
+**Learning:** In Next.js App Router, unhandled exceptions in Server Components can crash the request process and lead to a 500 Internal Server Error, posing a localized Denial of Service (DoS) risk and poor user experience. Dynamic route parameters must always be treated as untrusted input.
+**Prevention:** Always wrap functions that parse or decode dynamic URL parameters (like `decodeURIComponent()` or `JSON.parse()`) in `try...catch` blocks to gracefully handle malformed input and return a controlled error response (e.g., a "Not Found" or "Invalid URL" UI).

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,14 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug: string;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    // SECURITY: Prevent unhandled URIError crashes from malformed encoded slugs (DoS risk)
+    console.warn(`[SECURITY] Invalid URI component in slug: ${slug}`);
+    return <div className="text-center text-red-500 p-10">Invalid album URL.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +123,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Calling `decodeURIComponent()` directly on dynamic route parameters (`params.slug`) without a `try...catch` block allowed attackers to craft malformed URLs (e.g., `/portfolio/%C2`) that cause an unhandled `URIError`.
🎯 Impact: In Next.js App Router, unhandled exceptions in Server Components can crash the request process and lead to a 500 Internal Server Error, posing a localized Denial of Service (DoS) risk and poor user experience.
🔧 Fix: Wrapped the `decodeURIComponent(slug)` call in a `try...catch` block. If an error is caught, it logs a security warning and returns a graceful error UI message ("Invalid album URL") instead of crashing.
✅ Verification: Ensure the app builds (`npm run build`) and the tests pass (`bun test`). Attempting to navigate to `/portfolio/%C2` will no longer crash the server but will cleanly display the error UI.

---
*PR created automatically by Jules for task [13122160418936455288](https://jules.google.com/task/13122160418936455288) started by @Giorey01*