### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix URIError crash risk in dynamic portfolio routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Prevent Server Crash via URIError on Untrusted Route Parameters
+**Vulnerability:** In dynamic routes like `src/app/portfolio/[slug]/page.tsx`, passing an untrusted parameter directly into `decodeURIComponent()` risks causing an unhandled `URIError` when the user supplies a malformed string (e.g., `%`). This crashes the server and returns a 500 error instead of a graceful 4xx response, representing a Denial of Service risk for the page.
+**Learning:** Next.js dynamic parameters are completely untrusted inputs that must be treated cautiously. Functions like `decodeURIComponent()` or `JSON.parse()` can throw unhandled runtime exceptions.
+**Prevention:** Wrap all decodings/parsing of dynamic route parameters in `try...catch` blocks. Return a safe, controlled user interface if parsing fails, rather than crashing the page rendering process.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -80,8 +80,15 @@ export const generateStaticParams = async () => {
 const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
-  // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Decodifica eventuali caratteri speciali in modo sicuro per evitare crash
+  // se l'utente fornisce un input malformato (es. '%').
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (e) {
+    console.warn(`[SECURITY] Invalid URI encoding in slug: ${slug}`);
+    return <div className="text-center text-red-500 p-10">Invalid album URL format.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +123,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The dynamic portfolio slug param was passed directly to decodeURIComponent. An untrusted input containing malformed URL encoding (like an isolated `%`) would throw an unhandled URIError, crashing the server rendering process and returning a generic 500 Internal Server Error.
🎯 Impact: Denial of Service (DoS) risk per-page. Malicious actors could intentionally request broken URLs to cause 500 errors and trigger alerting noise, or create bad links that crash the application logic.
🔧 Fix: Wrapped the `decodeURIComponent(slug)` call inside a `try...catch` block. If decoding fails, the code catches the exception, logs a warning for visibility without leaking the stack trace, and safely renders a 400-level-equivalent React error view indicating the album URL is invalid. Also optimized the h1 tag rendering to reuse the decoded slug.
✅ Verification: Ran `bun test` and `bun run build`. Verified the build completes successfully and the changes are purely defensive without negatively impacting the original behavior. Updated Sentinel's journal.

---
*PR created automatically by Jules for task [8027702630861198920](https://jules.google.com/task/8027702630861198920) started by @Giorey01*