### PR TITLE
🛡️ Sentinel: [HIGH] Fix URIError crash in dynamic routing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2025-04-04 - [HIGH] Prevent URIError (500 Crash) from Untrusted decodeURIComponent Input
+**Vulnerability:** The application used `decodeURIComponent(slug)` directly on a dynamic route parameter (`params.slug`). If an attacker provides a malformed URL parameter (like `"%"`), it triggers an unhandled `URIError` crash, resulting in a 500 Internal Server Error.
+**Learning:** Next.js dynamic route parameters are effectively untrusted user input. Standard JavaScript decoding and parsing functions (`decodeURIComponent`, `JSON.parse`) must always be treated carefully when operating on untrusted input to prevent unhandled exceptions that can degrade availability.
+**Prevention:** Always wrap `decodeURIComponent`, `decodeURI`, and `JSON.parse` operations that handle external input within `try...catch` blocks to gracefully handle malformed data and return an appropriate error UI or response instead of crashing the server.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,14 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Wrapped in try...catch to prevent URIError crashes from malformed inputs like "%"
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (e) {
+    console.error(`Invalid slug (URIError) provided: ${slug}`);
+    return <div className="text-center text-red-500 p-10">Invalid URL parameters.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +123,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application used `decodeURIComponent` directly on the dynamic `params.slug` route parameter without error handling.
🎯 **Impact:** If an attacker supplied a malformed URL component (e.g., `%`), it triggered an unhandled `URIError`, causing a 500 Internal Server Error and creating a Denial of Service risk for that route.
🔧 **Fix:** Wrapped the decoding function in a `try...catch` block. If decoding fails, it now safely catches the error and returns a generic "Invalid URL parameters" fallback UI, ensuring the application remains stable. Re-used the safely decoded string in the JSX payload to prevent the error from resurfacing further down the file.
✅ **Verification:** Verify that the project tests still pass. Attempting to navigate to `/portfolio/%` should now result in the fallback UI instead of crashing the Next.js server.

---
*PR created automatically by Jules for task [15652804877674544622](https://jules.google.com/task/15652804877674544622) started by @Giorey01*