### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled URIError in decodeURIComponent

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Unhandled URIError in dynamic route parameter decoding
+**Vulnerability:** The dynamic route parameter `slug` was passed directly to `decodeURIComponent()` without a `try...catch` block. A maliciously malformed URL could cause an unhandled `URIError`, resulting in a 500 Internal Server Error crash.
+**Learning:** Dynamic route parameters (`params.slug`) are untrusted user input and can contain invalid encoding.
+**Prevention:** Always wrap functions that decode or parse untrusted input (like `decodeURIComponent` or `JSON.parse`) in `try...catch` blocks to fail gracefully and prevent server crashes.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug: string;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.warn(`[SECURITY] Failed to decode slug parameter: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid URL parameters.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** The dynamic route parameter `slug` was passed directly to `decodeURIComponent()` without a `try...catch` block. A maliciously malformed URL could cause an unhandled `URIError`, resulting in a 500 Internal Server Error crash.
**Impact:** A malicious actor could repeatedly request malformed URLs to exhaust server resources or cause application crashes.
**Fix:** Wrapped the `decodeURIComponent(slug)` call inside a `try...catch` block. If `decodeURIComponent` throws a `URIError`, the route handler gracefully handles it by returning a simple `<div>` error message rather than crashing the Next.js process. Additionally, updated both uses of `decodeURIComponent(slug)` in the file to use the safe `decodedSlug` variable.
**Verification:** Ran `bun test` and `bun run build` successfully.

---
*PR created automatically by Jules for task [7661520592789475990](https://jules.google.com/task/7661520592789475990) started by @Giorey01*