### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Unhandled URIError DoS from Untrusted Input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Prevent Unhandled URIError DoS from Untrusted Input
+**Vulnerability:** The application was directly passing untrusted user input (URL parameters like `params.slug`) to `decodeURIComponent()` without a `try...catch` block. If a malicious user supplies a malformed URI component (e.g., `%C2`), it causes Node.js to throw a `URIError`, resulting in an unhandled exception and a 500 Internal Server Error crash.
+**Learning:** Any native function that parses or decodes strings (like `decodeURIComponent`, `JSON.parse`) can throw exceptions if the input is malformed. When these functions are fed untrusted input (e.g., URL params, query strings, headers), they become a vector for Denial of Service (DoS) attacks.
+**Prevention:** Always wrap functions that decode or parse untrusted user input in a `try...catch` block to handle malformed data gracefully and prevent server crashes.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug: string;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Invalid slug parameter: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid URL parameter provided.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Prevent Unhandled URIError DoS from Untrusted Input

* 🚨 **Severity:** MEDIUM
* 💡 **Vulnerability:** The application was directly passing untrusted user input (URL parameters like `params.slug`) to `decodeURIComponent()` without a `try...catch` block.
* 🎯 **Impact:** If a malicious user supplies a malformed URI component (e.g., `%C2`), it causes Node.js to throw a `URIError`, resulting in an unhandled exception and a 500 Internal Server Error crash, which can be leveraged for a Denial of Service.
* 🔧 **Fix:** Wrapped `decodeURIComponent` in a `try...catch` block. If an error is caught, we handle it gracefully by returning a safe error message UI to the user, preventing a server crash. Also updated `.jules/sentinel.md` with this critical learning.
* ✅ **Verification:** Ran `bun run lint`, `bun run build`, and `bun test`. All checks passed.

---
*PR created automatically by Jules for task [206249429370519376](https://jules.google.com/task/206249429370519376) started by @Giorey01*