### PR TITLE
🛡️ Sentinel: [HIGH] Fix unhandled URIError in decodeURIComponent

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2026-04-08 - [Unhandled URIError from decodeURIComponent]
+**Vulnerability:** Next.js pages or API routes calling `decodeURIComponent()` directly on user input (like dynamic route parameters `params.slug`) without a `try/catch` block.
+**Learning:** If a user passes an invalid URL-encoded string (e.g., `%E0%A4%A`), `decodeURIComponent` throws a `URIError`. In Next.js Server Components, this unhandled exception crashes the request, resulting in a 500 Internal Server Error, which can be exploited for a Denial of Service (DoS).
+**Prevention:** Always wrap `decodeURIComponent` (and `JSON.parse`) in a `try/catch` block when processing untrusted input, falling back gracefully to the raw input or a 400 error.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Wrapped in try-catch to prevent URIError crashes on malformed slugs
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.warn(`Failed to decode slug "${slug}":`, error);
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `decodeURIComponent` was called directly on untrusted user input (`params.slug`). If an invalid URL-encoded string is passed, it throws a `URIError`. In Next.js Server Components, this unhandled exception crashes the request rendering, resulting in a 500 Internal Server Error.
🎯 Impact: An attacker could intentionally request malformed URLs to cause repeated 500 errors, potentially leading to a Denial of Service (DoS) condition or resource exhaustion.
🔧 Fix: Wrapped the `decodeURIComponent(slug)` call in a `try...catch` block. If an error is caught, it logs a warning and falls back to using the raw un-decoded `slug` safely. 
✅ Verification: Ran `bun run lint`, `bun test`, and `bun run build`. All checks passed. Added a journal entry to `.jules/sentinel.md` to document the Next.js specific vulnerability regarding unhandled `decodeURIComponent` exceptions on untrusted dynamic route parameters.

---
*PR created automatically by Jules for task [11425963319033429102](https://jules.google.com/task/11425963319033429102) started by @Giorey01*