### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unhandled URIError in Dynamic Route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2026-04-13 - [MEDIUM] Prevent Unhandled URIError in Dynamic Routes
+**Vulnerability:** Unhandled `URIError` due to `decodeURIComponent` being called on unvalidated, untrusted dynamic route parameters (e.g., malformed % sequences) in Next.js App Router (e.g. `/portfolio/[slug]`). This could lead to 500 Internal Server Error crashes, presenting a Denial of Service risk.
+**Learning:** Next.js dynamic route parameters (e.g. `params.slug`) must be treated as untrusted user input. Built-in functions that decode or parse this input can throw exceptions if the input is malformed.
+**Prevention:** Always wrap functions that decode or parse dynamic route parameters (such as `decodeURIComponent()` or `JSON.parse()`) in a `try...catch` block and return a graceful error response instead of crashing the server.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Invalid URI component in slug: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid URL parameters provided.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled exception (`URIError`) when processing untrusted dynamic route parameters. If an attacker hits the `/portfolio/%` route, `decodeURIComponent` throws, causing a 500 Internal Server Error and presenting a mild Denial of Service risk to the Next.js process.
🎯 Impact: Prevents server crash / 500 error from unhandled exceptions on invalid percent-encoded user input.
🔧 Fix: Wrapped the `decodeURIComponent` call in a `try...catch` block. If the URI is malformed, the page now safely returns a styled error message indicating invalid URL parameters. Reused the `decodedSlug` variable further down in the JSX to avoid duplicate parsing risks.
✅ Verification: Ran `bun test`, `bun run lint`, and `bun run build`. Verified that passing malformed URL parameters gracefully renders an error div rather than crashing the Next.js instance.

Also documented the finding in `.jules/sentinel.md` as required.

---
*PR created automatically by Jules for task [5067472806543489826](https://jules.google.com/task/5067472806543489826) started by @Giorey01*