### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled URIError vulnerability in dynamic routing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+## 2024-04-14 - Fix unhandled URIError vulnerability in dynamic routing
+**Vulnerability:** Unhandled `URIError` causing 500 Internal Server Error when decoding malformed dynamic route parameter.
+**Learning:** In Next.js dynamic routing, functions like `decodeURIComponent` must be wrapped in `try...catch` when handling user input (`params`), as malformed URI strings (e.g. `%`) will trigger an unhandled exception leading to a Denial of Service.
+**Prevention:** Always sanitize, validate, and try-catch untrusted URI components retrieved from `params` before executing decoding/parsing functions.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug: string;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Failed to decode slug "${slug}":`, error);
+    return <div className="text-center text-red-500 p-10">Invalid album URL.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled `URIError` causing 500 Internal Server Error when decoding malformed dynamic route parameter.
🎯 Impact: Denial of Service / App Crash if a user navigates to a malformed dynamic route parameter (e.g. `%`).
🔧 Fix: Wrapped `decodeURIComponent` in a try...catch block to handle the exception gracefully and return a UI error state.
✅ Verification: Ensure the app builds successfully. Try navigating to `/portfolio/%` locally - it should display "Invalid album URL" instead of a 500 Error stack trace.

---
*PR created automatically by Jules for task [4722341006124077620](https://jules.google.com/task/4722341006124077620) started by @Giorey01*