### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix URIError crash in decoding route parameter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Fix URIError crash in decoding route parameter
+**Vulnerability:** Calling `decodeURIComponent()` on dynamic route parameters (`params.slug`) without a `try...catch` block. If a malformed encoded string (e.g., `%`) is passed via the URL, it throws an unhandled `URIError`, causing the Next.js App Router server component to crash and return a 500 Internal Server Error.
+**Learning:** Dynamic route parameters in Next.js (App Router) must be treated as untrusted user input. Any operation that parses or decodes them is susceptible to invalid formatting and can lead to a crash if errors are not explicitly caught.
+**Prevention:** Always wrap functions like `decodeURIComponent()` or `JSON.parse()` when applied to untrusted route parameters in a `try...catch` block and provide a graceful fallback.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,14 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // Wrap in try-catch to prevent URIError crashes with malformed input
+  let decodedSlug = "";
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Failed to decode slug "${slug}":`, error);
+    return <div className="text-center text-red-500 p-10">Invalid album format.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +123,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Calling `decodeURIComponent()` on dynamic route parameters without a `try...catch` block causes an unhandled `URIError` when passing malformed strings (like `%`). This results in the Next.js server component crashing and throwing a 500 error.
🎯 Impact: Denial of Service (DoS) or application crash, causing a degraded experience and throwing unhandled 500 errors to users and search engine bots.
🔧 Fix: Wrapped the `decodeURIComponent(slug)` in a `try...catch` block. If the URI is malformed and cannot be decoded, it is safely caught and returns a user-friendly invalid album format component, preventing the server from crashing.
✅ Verification: Tests passing, lint passing, `decodeURIComponent('%')` no longer crashes the `PortfolioPage` component.

---
*PR created automatically by Jules for task [1154461361003005094](https://jules.google.com/task/1154461361003005094) started by @Giorey01*