### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix URIError unhandled exception in dynamic route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2026-04-16 - [MEDIUM] Fix URIError unhandled exception in dynamic route
+**Vulnerability:** In Next.js App Router, directly calling `decodeURIComponent` or `JSON.parse` on dynamic route parameters (like `params.slug`) without a `try...catch` block can cause an unhandled `URIError` exception if the parameter is malformed (e.g. contains `%`), leading to a server crash (500 error).
+**Learning:** Dynamic route parameters should be treated as untrusted user input. Attempting to decode or parse them without handling potential format errors creates a denial-of-service vector where an attacker can crash the rendering process by sending crafted URLs.
+**Prevention:** Always wrap functions that decode or parse dynamic route parameters (e.g. `decodeURIComponent()`, `JSON.parse()`) in a `try...catch` block and return a safe fallback or error page when parsing fails.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,14 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Gestione degli errori per decodifica di parametri URL malformati
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.warn(`[SECURITY] Invalid URI component in slug: ${slug}`);
+    return <div className="text-center text-red-500 p-10">Invalid album URL.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +123,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Passing dynamic route parameters (e.g. `params.slug`) directly into `decodeURIComponent` without catching exceptions allows a malformed URI component (`%`) to throw an unhandled `URIError`, causing a 500 Server Error crash during the rendering phase.
🎯 Impact: This creates a minor Denial of Service (DoS) and application instability, where an attacker or a web crawler traversing a malformed link can intentionally trigger 500 errors and pollute server logs.
🔧 Fix: Wrapped the `decodeURIComponent` call in a `try...catch` block in `src/app/portfolio/[slug]/page.tsx`. If it fails, a warning is logged safely, and the component returns a generic "Invalid album URL" UI block rather than crashing. 
✅ Verification: Pass `%` or other malformed components to the `/portfolio/` route and verify the application returns the error view instead of failing with a 500.

---
*PR created automatically by Jules for task [789835615769468170](https://jules.google.com/task/789835615769468170) started by @Giorey01*