### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled URIError on malformed portfolio slug

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2026-04-17 - [MEDIUM] Prevent Unhandled URIError from Malformed Slugs
+**Vulnerability:** In Next.js App Router, dynamic route parameters (like `slug`) represent untrusted user input. Calling `decodeURIComponent(slug)` directly without a `try...catch` block can cause the application to throw an unhandled `URIError` if a user provides a malformed URI component (e.g., `%C2`), potentially leading to 500 Internal Server Error crashes.
+**Learning:** Always treat URL parameters as untrusted input. Functions that parse or decode them must be wrapped in error-handling blocks to prevent unhandled exceptions and subsequent application instability.
+**Prevention:** Wrap parsing functions like `decodeURIComponent` or `JSON.parse` in a `try...catch` block, log the error securely, and return a safe, generic error message to the user.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,15 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Il parametro dinamico "slug" rappresenta input non attendibile.
+  // decodeURIComponent può generare una URIError se viene passata una stringa malformata (es. "%C2").
+  let decodedSlug: string;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`[SECURITY] URIError: Malformed URI component in slug: ${slug}`);
+    return <div className="text-center text-red-500 p-10">Invalid URL format.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +124,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** In Next.js App Router, dynamic route parameters (like `slug`) represent untrusted user input. Calling `decodeURIComponent(slug)` directly without a `try...catch` block can cause the application to throw an unhandled `URIError` if a user provides a malformed URI component (e.g., `%C2`), potentially leading to 500 Internal Server Error crashes or DoS.
🎯 **Impact:** An attacker or a misconfigured external link could cause application instability and unhandled exceptions by passing malformed encoded strings to the portfolio URL path.
🔧 **Fix:** Wrapped the `decodeURIComponent` call in a `try...catch` block, returning a safe, generic fallback error state gracefully. Also avoided a redundant second decoding call in the `<h1>` tag.
✅ **Verification:** Ran `bun test` and `bun run lint` successfully. Verified that the `try...catch` block safely captures malformed input and renders a standard generic text error without crashing the main application thread.

---
*PR created automatically by Jules for task [615826327474633315](https://jules.google.com/task/615826327474633315) started by @Giorey01*