### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled URIError in dynamic route parameter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [Medium] Fix unhandled URIError in dynamic route parameter
+**Vulnerability:** A Next.js dynamic route `decodeURIComponent` parameter was used without being wrapped in a `try...catch` block. This leads to a `URIError` when passing invalid URL characters, eventually causing a 500 Internal Server Error application crash.
+**Learning:** Next.js dynamic parameters are completely untrusted inputs (e.g. from `/portfolio/%2`). Since `decodeURIComponent` throws an exception for malformed URI components, it's essential to safely wrap it or handle the error effectively.
+**Prevention:** Always sanitize and `try...catch` when using `decodeURIComponent` (or `JSON.parse`) on route parameters to prevent server crashes.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -80,8 +80,15 @@ export const generateStaticParams = async () => {
 const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
-  // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Decodifica eventuali caratteri speciali in modo sicuro
+  // Previene URIError crash su input malformati (es. %2)
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Invalid URL parameter: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid album URL.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +123,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** A Next.js dynamic route parameter was using `decodeURIComponent` without a `try...catch` block. This could lead to a `URIError` when passing invalid URL characters, causing a 500 Internal Server Error crash (a minor DoS).
**Impact:** A user could craft a malicious URL to cause application errors and unhandled exceptions.
**Fix:** Wrapped the `decodeURIComponent(slug)` call inside a `try...catch` block and returned an error message UI in case of failure. Also refactored to reuse the safe `decodedSlug` variable in the component JSX.
**Verification:** Running `bun test` and `bun run build` verifies that there are no regressions.

---
*PR created automatically by Jules for task [4609344152589558581](https://jules.google.com/task/4609344152589558581) started by @Giorey01*