### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled URIError in dynamic route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Fix unhandled URIError in dynamic route
+**Vulnerability:** The dynamic route parameter `params.slug` in `src/app/portfolio/[slug]/page.tsx` was passed directly to `decodeURIComponent()` without a `try...catch` block. This allows an attacker to send malformed encoded strings (like `%`), triggering an unhandled `URIError` and causing a 500 Internal Server Error crash (DoS risk).
+**Learning:** In Next.js App Router, dynamic route parameters must be treated as untrusted user input. Functions that parse or decode them, such as `decodeURIComponent()`, must be wrapped in `try...catch` blocks to prevent unhandled exceptions.
+**Prevention:** Always wrap `decodeURIComponent()` or `JSON.parse()` calls on user input (including route params) in a `try...catch` block and return a graceful error response instead of crashing the process.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Invalid slug encoding: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid URL format.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The dynamic route parameter `params.slug` was passed directly to `decodeURIComponent()` without a `try...catch` block. This allows an attacker to send malformed encoded strings (like `%`), triggering an unhandled `URIError` and causing a 500 Internal Server Error crash (DoS risk).
🎯 Impact: An attacker could crash the process or degrade the service by sending continuous malformed requests to dynamic routes.
🔧 Fix: Wrapped the `decodeURIComponent` in a `try...catch` block and returned a user-friendly error response instead.
✅ Verification: Ran `bun test` and `bun run lint` successfully. Verified logic locally.

---
*PR created automatically by Jules for task [4693345777636749173](https://jules.google.com/task/4693345777636749173) started by @Giorey01*