### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix URIError 500 crash in portfolio slug decoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Prevent 500 Error Crash from Malformed URI Components
+**Vulnerability:** The application was calling `decodeURIComponent(slug)` directly on a user-provided dynamic route parameter (`slug`) in `src/app/portfolio/[slug]/page.tsx`. If a user visited a URL with a malformed URI sequence (e.g., `%`), `decodeURIComponent` threw an unhandled `URIError`, causing a 500 Internal Server Error crash for that request.
+**Learning:** In Next.js App Router, dynamic route parameters (like `params.slug`) should be treated as untrusted user input. Built-in JS functions that parse strings (like `decodeURIComponent` or `JSON.parse`) can throw exceptions on malformed input.
+**Prevention:** Always wrap functions that decode or parse untrusted user input in a `try...catch` block. Catch the error, log it securely, and return a graceful fallback UI (like a 400 Bad Request or a generic "Invalid URL" message) instead of letting the application crash.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -80,8 +80,16 @@ export const generateStaticParams = async () => {
 const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
-  // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
+  // Wrap in try-catch to prevent URIError crashes if the slug contains malformed URI components
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (e) {
+    // If decode fails, log it and return a safe fallback or error page to prevent a 500 error
+    console.error(`[SECURITY] Failed to decode slug "${slug}":`, e);
+    return <div className="text-center text-red-500 p-10">Invalid album URL.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +124,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was calling `decodeURIComponent(slug)` directly on a user-provided dynamic route parameter (`slug`) in `src/app/portfolio/[slug]/page.tsx`. If a user visited a URL with a malformed URI sequence (e.g., `%`), `decodeURIComponent` threw an unhandled `URIError`.
🎯 Impact: This caused a 500 Internal Server Error crash for that specific request, providing a poor user experience and potentially allowing an attacker to cause application errors via crafted URLs.
🔧 Fix: Wrapped the `decodeURIComponent` call in a `try...catch` block. It now safely attempts to decode the slug, and if it fails, it logs a security warning and returns a safe fallback "Invalid album URL" UI message instead of crashing the server.
✅ Verification: Start the dev server and visit a URL like `http://localhost:3000/portfolio/%`. The page should display the fallback error message instead of throwing a 500 error in the server console.

Also updated the `.jules/sentinel.md` journal with this finding.

---
*PR created automatically by Jules for task [515086397054896294](https://jules.google.com/task/515086397054896294) started by @Giorey01*