### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled URIError in portfolio slug decoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-18 - [Unhandled Exception in URL Params]
+**Vulnerability:** Calling `decodeURIComponent()` on dynamic route parameters (e.g. `params.slug`) without a try-catch block leads to an unhandled `URIError` when malformed inputs like `%` are provided, crashing the endpoint with a 500 error.
+**Learning:** Dynamic Next.js URL parameters are untrusted user input. Any operation that decodes or parses them (like `decodeURIComponent` or `JSON.parse`) MUST be wrapped in a `try...catch` block.
+**Prevention:** Treat all URL parameters as untrusted inputs and defensively code with try-catch blocks when performing explicit decoding/parsing.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,15 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Il parametro dinamico 'slug' è input non attendibile.
+  // decodeURIComponent può lanciare URIError se l'input è malformato (es. '%').
+  let decodedSlug: string;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Invalid slug provided: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid album URL.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +124,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unhandled Exception. Calling `decodeURIComponent(slug)` directly on an untrusted dynamic route parameter throws a `URIError` when malformed payloads (e.g. `%`) are supplied. Next.js does not handle this automatically in server components, resulting in a 500 error crash.
🎯 **Impact:** Potential Denial of Service (DoS) or application instability. An attacker or web crawler testing endpoints with malformed payloads could generate excessive unhandled server-side exceptions.
🔧 **Fix:** Wrapped the decoding logic in a `try...catch` block. If a `URIError` is caught, we securely fail by logging the error and returning a safe error state (`<div className="text-center text-red-500 p-10">Invalid album URL.</div>`), avoiding application crashes. Also reused the decoded value to avoid duplicated processing. Added a journal entry to `.jules/sentinel.md` documenting the learning.
✅ **Verification:** Verified by throwing `%` manually in test environments producing a caught `URIError`. Passed `bun run lint`, `bun test`, and `bun run build`.

---
*PR created automatically by Jules for task [12051410844490864161](https://jules.google.com/task/12051410844490864161) started by @Giorey01*