### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix 500 error from malformed URI components

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - [MEDIUM] Fix 500 error from malformed URI components
+**Vulnerability:** In Next.js App Router, calling `decodeURIComponent` directly on dynamic route parameters (e.g., `params.slug`) without a `try...catch` block creates a vulnerability where malformed URLs (e.g. `%E0%A4%A`) throw an unhandled `URIError`, causing a 500 Internal Server Error crash.
+**Learning:** Dynamic route parameters are untrusted user input. Functions that parse or decode them must be robust enough to handle invalid data gracefully.
+**Prevention:** Always wrap parsing functions like `decodeURIComponent()` or `JSON.parse()` on user input in a `try...catch` block to handle errors safely and return a friendly error message or 400 Bad Request status.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,14 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  // SECURITY: Gestisce eventuali errori di decodifica (es. URI malformato %E0%A4%A) che causerebbero un errore 500
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (e) {
+    console.error(`Failed to decode slug: ${slug}`, e);
+    return <div className="text-center text-red-500 p-10">Invalid URL format.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +123,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** In Next.js App Router, dynamic route parameters (like `params.slug`) are untrusted user inputs. If a user visits a URL with a malformed encoded string (e.g., `%E0%A4%A`), calling `decodeURIComponent()` directly on it will throw an unhandled `URIError`, causing the server to crash with a 500 Internal Server Error. This is a potential denial-of-service vector if an attacker repeatedly requests malformed URLs, exhausting server resources logging unhandled exceptions.
🎯 **Impact:** Prevents 500 server crashes and potential error logging exhaustion.
🔧 **Fix:** Wrapped the `decodeURIComponent(slug)` call in a `try...catch` block. If decoding fails, the page gracefully falls back to returning a "Invalid URL format" error message in the UI rather than crashing the server. Added journal entry to track this vulnerability pattern.
✅ **Verification:** Run `bun run build` and `bun test` to ensure changes don't break functionality. Navigating to `/portfolio/%E0%A4%A` now displays a graceful error message instead of throwing an unhandled exception.

---
*PR created automatically by Jules for task [10502940424762670307](https://jules.google.com/task/10502940424762670307) started by @Giorey01*