### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix URIError crash vulnerability on malformed URL parameters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+## 2026-04-24 - Fix URIError crash vulnerability on malformed URL parameters
+**Vulnerability:** Next.js dynamic route parameters were passed directly to `decodeURIComponent` without exception handling.
+**Learning:** Malformed URL parameters (like `%`) can cause unhandled URIErrors during server-side rendering, leading to an uncaught exception and a 500 internal server error (Denial of Service risk).
+**Prevention:** Always wrap `decodeURIComponent(slug)` in a `try...catch` block when handling untrusted user input from dynamic route parameters to fail securely and provide graceful error messages.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug = slug;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Invalid URL parameter: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid album URL.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
- Addressed a DoS risk where passing a malformed URL parameter (like `%`) directly into `decodeURIComponent` threw an uncaught `URIError`, crashing the route.
- Ensured graceful error handling by returning a fallback UI component on failure.
- Updated the Sentinel journal tracking this type of unhandled promise rejection vulnerability.

---
*PR created automatically by Jules for task [8404182140143159181](https://jules.google.com/task/8404182140143159181) started by @Giorey01*