### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled URIError in dynamic route parameter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The rate limiter in the contact form API was extracting the client IP using `x-forwarded-for.split(',')[0]`. This allows a malicious user to trivially bypass rate limits by spoofing the `X-Forwarded-For` header and supplying a comma-separated list of fake IPs.
 **Learning:** In environments behind reverse proxies (like Vercel), the outermost trusted proxy appends the real client IP to the *end* of the `x-forwarded-for` chain. Taking the first IP is insecure because the client can inject arbitrary values at the start of the chain.
 **Prevention:** Always extract the *last* IP address in the `x-forwarded-for` chain (or rely on platform-specific verified headers) to securely identify clients for rate limiting and prevent IP spoofing bypasses.
+
+## 2024-05-24 - Unhandled URIError in Dynamic Parameters
+**Vulnerability:** Next.js dynamic route parameters (e.g., `params.slug`) were passed directly to `decodeURIComponent()` without a `try...catch` block. If a user provided a malformed URI component (like `%`), it caused an unhandled `URIError` and a 500 Internal Server Error, leading to a potential Denial of Service (DoS).
+**Learning:** Any dynamic parameter from the URL must be treated as untrusted user input. Functions that parse or decode them (like `decodeURIComponent` or `JSON.parse`) can throw exceptions on invalid input and crash the rendering process.
+**Prevention:** Always wrap parsing or decoding of URL parameters in `try...catch` blocks. Return a fallback UI or a friendly error message when decoding fails, rather than letting the exception bubble up to the server.

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -81,7 +81,13 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
   const { slug } = params; // Estrae lo slug dall'URL (es: "giappone")
 
   // Decodifica eventuali caratteri speciali (es. spazi codificati come %20 in URL)
-  const decodedSlug = decodeURIComponent(slug);
+  let decodedSlug: string;
+  try {
+    decodedSlug = decodeURIComponent(slug);
+  } catch (error) {
+    console.error(`Invalid URI in slug parameter: ${slug}`, error);
+    return <div className="text-center text-red-500 p-10">Invalid URL parameter.</div>;
+  }
 
   const jsonFilePath = path.join(process.cwd(), 'src', 'data', 'image_urls.json');
   let imageData: ImageUrlsData = {};
@@ -116,7 +122,7 @@ const PortfolioPage = async ({ params }: PortfolioPageProps) => {
     <div className="p-4 md:p-8 lg:p-14">
       {/* Titolo in alto: formatta lo slug sostituendo i trattini con gli spazi e mettendolo in maiuscoletto */}
       <h1 className="text-3xl md:text-4xl text-center font-bold p-6 md:p-10 capitalize">
-        {decodeURIComponent(slug).replace(/-/g, " ")}
+        {decodedSlug.replace(/-/g, " ")}
       </h1>
 
       {/* Passiamo le immagini del server al Client Component ImageGallery


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled `URIError` caused by passing malformed dynamic route parameters (e.g., `params.slug`) directly to `decodeURIComponent()` in `src/app/portfolio/[slug]/page.tsx`, leading to 500 Internal Server Error crashes.
🎯 Impact: Denial of Service (DoS) risk where malformed URLs crash the application server loop or return generic 500 pages.
🔧 Fix: Wrapped the `decodeURIComponent` in a `try...catch` block. It logs the invalid parameter and gracefully returns a user-friendly error message component instead of crashing the server. Added a corresponding entry to the Sentinel journal for future reference.
✅ Verification: Ran `bun test`, `bun run lint`, and `bun run build`. Attempting to visit `/portfolio/%` will now display a neat error message instead of crashing the Next.js renderer.

---
*PR created automatically by Jules for task [16132598831023577660](https://jules.google.com/task/16132598831023577660) started by @Giorey01*