### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix PII leakage via insecure test account fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Unhandled `URIError` when decoding URL parameters (e.g., `decodeURIComponent(slug)`) causing a 500 Internal Server Error / application crash when a user provides a malformed URL parameter like `/%A`.
 **Learning:** Dynamic route parameters (`params.slug`) should always be treated as untrusted user input, even in functions like `decodeURIComponent()` which can throw native runtime errors.
 **Prevention:** Wrap functions that decode or parse user input (like `decodeURIComponent()` or `JSON.parse()`) in a `try...catch` block to gracefully handle invalid input and return an appropriate error response (or safe fallback UI) without crashing the server.
+
+## 2024-05-24 - [CRITICAL] Prevent PII Leakage via Insecure Test Account Fallbacks
+**Vulnerability:** The contact form API automatically created an Ethereal test account and logged the email preview URL whenever the environment was not 'production' (`process.env.NODE_ENV !== 'production'`) and SMTP credentials were missing. This exposes user Personally Identifiable Information (PII) like emails and message contents in staging, preview, or testing environments.
+**Learning:** Relying on `NODE_ENV !== 'production'` to conditionally enable test features that process sensitive data is insecure because non-production environments are often publicly accessible or shared.
+**Prevention:** Always gate test fallbacks and mock services that handle sensitive user data using explicit feature flags (e.g., `process.env.ENABLE_TEST_EMAIL === 'true'`) to ensure they are only active when intentionally enabled, preventing accidental data leakage.

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -111,10 +111,10 @@ export async function POST(request: Request) {
       !EMAIL_FROM ||
       !EMAIL_TO
     ) {
-      // Controlliamo se ci troviamo in ambiente di sviluppo locale.
-      // E' un ottimo trucco per Next.js per facilitare lo sviluppo!
-      if (process.env.NODE_ENV !== 'production') {
-        console.warn('Configurazione email mancante. Utilizzo account di test Ethereal per lo sviluppo locale.');
+      // Controlliamo se è esplicitamente abilitato l'account di test (tramite feature flag).
+      // Evitiamo di basarci solo su NODE_ENV !== 'production' per evitare leak di PII in staging.
+      if (process.env.ENABLE_TEST_EMAIL === 'true') {
+        console.warn('Configurazione email mancante. Utilizzo account di test Ethereal (ENABLE_TEST_EMAIL=true).');
 
         // Riutilizziamo l'account e il transporter se li abbiamo già creati.
         // Se non esistono ancora (prima richiesta), li creiamo e li salviamo.
@@ -187,7 +187,7 @@ export async function POST(request: Request) {
 
       // Se stiamo usando l'account di test (Ethereal), possiamo recuperare l'URL
       // del messaggio per poterlo visualizzare nel browser!
-      if (process.env.NODE_ENV !== 'production' && info.messageId) {
+      if (process.env.ENABLE_TEST_EMAIL === 'true' && info.messageId) {
         const testMessageUrl = nodemailer.getTestMessageUrl(info);
         if (testMessageUrl) {
           console.log('Preview URL: %s', testMessageUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The contact form API automatically created an Ethereal test email account and logged the preview URL containing the message payload and sender email whenever the environment was not 'production' and SMTP credentials were missing. This exposed PII in non-production environments like staging or previews.
🎯 Impact: An attacker or unauthorized user viewing logs in a staging/preview environment could read sensitive user messages and email addresses sent via the contact form.
🔧 Fix: Replaced the implicit `process.env.NODE_ENV !== 'production'` fallback with an explicit feature flag `process.env.ENABLE_TEST_EMAIL === 'true'`. This ensures the test account mechanism is strictly opt-in. Added a learning to `.jules/sentinel.md`.
✅ Verification: Ran `bun test` and `bun run lint` successfully. Examined code to ensure test accounts are only initialized when `ENABLE_TEST_EMAIL` is explicitly set to `'true'`.

---
*PR created automatically by Jules for task [3947723566505986820](https://jules.google.com/task/3947723566505986820) started by @Giorey01*